### PR TITLE
Remove absolute path

### DIFF
--- a/scripts/migration-add.ps1
+++ b/scripts/migration-add.ps1
@@ -1,0 +1,10 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$MigrationName
+)
+
+$repoRoot = Join-Path -Path "$PSScriptRoot" -ChildPath ".."
+$infrastructreProj = Join-Path -Path $repoRoot  -ChildPath "src" -AdditionalChildPath "api", "MixServer.Infrastructure"
+
+dotnet ef migrations add "$MigrationName"  --project $infrastructreProj

--- a/scripts/migration-remove.ps1
+++ b/scripts/migration-remove.ps1
@@ -1,0 +1,4 @@
+$repoRoot = Join-Path -Path "$PSScriptRoot" -ChildPath ".."
+$infrastructreProj = Join-Path -Path $repoRoot  -ChildPath "src" -AdditionalChildPath "api", "MixServer.Infrastructure"
+
+dotnet ef migrations remove --project (Resolve-Path $infrastructreProj).Path

--- a/src/api/MixServer.Application/FileExplorer/Commands/CopyNode/CopyNodeCommand.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/CopyNode/CopyNodeCommand.cs
@@ -4,9 +4,9 @@ namespace MixServer.Application.FileExplorer.Commands.CopyNode;
 
 public class CopyNodeCommand
 {
-    public required NodePathDto SourcePath { get; set; }
+    public required NodePathRequestDto SourcePath { get; set; }
     
-    public required NodePathDto DestinationPath { get; set; }
+    public required NodePathRequestDto DestinationPath { get; set; }
     
     public bool Move { get; set; }
     

--- a/src/api/MixServer.Application/FileExplorer/Commands/CopyNode/CopyNodeCommand.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/CopyNode/CopyNodeCommand.cs
@@ -1,12 +1,12 @@
+using MixServer.Application.FileExplorer.Dtos;
+
 namespace MixServer.Application.FileExplorer.Commands.CopyNode;
 
 public class CopyNodeCommand
 {
-    public string SourceAbsolutePath { get; set; } = string.Empty;
+    public required NodePathDto SourcePath { get; set; }
     
-    public string DestinationFolder { get; set; } = string.Empty;
-    
-    public string DestinationName { get; set; } = string.Empty;
+    public required NodePathDto DestinationPath { get; set; }
     
     public bool Move { get; set; }
     

--- a/src/api/MixServer.Application/FileExplorer/Commands/CopyNode/CopyNodeCommandCommandHandler.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/CopyNode/CopyNodeCommandCommandHandler.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using MixServer.Application.FileExplorer.Converters;
 using MixServer.Domain.FileExplorer.Services;
 using MixServer.Domain.Interfaces;
 
@@ -6,6 +7,7 @@ namespace MixServer.Application.FileExplorer.Commands.CopyNode;
 
 public class CopyNodeCommandCommandHandler(
     IFileService fileService,
+    INodePathDtoConverter nodePathDtoConverter,
     IValidator<CopyNodeCommand> validator)
     : ICommandHandler<CopyNodeCommand>
 {
@@ -14,9 +16,8 @@ public class CopyNodeCommandCommandHandler(
         await validator.ValidateAndThrowAsync(request);
 
         fileService.CopyNode(
-            request.SourceAbsolutePath,
-            request.DestinationFolder,
-            request.DestinationName,
+            nodePathDtoConverter.Convert(request.SourcePath),
+            nodePathDtoConverter.Convert(request.DestinationPath),
             request.Move,
             request.Overwrite);
     }

--- a/src/api/MixServer.Application/FileExplorer/Commands/CopyNode/CopyNodeCommandValidator.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/CopyNode/CopyNodeCommandValidator.cs
@@ -6,10 +6,10 @@ public class CopyNodeCommandValidator : AbstractValidator<CopyNodeCommand>
 {
     public CopyNodeCommandValidator()
     {
-        RuleFor(r => r.SourceAbsolutePath).NotEmpty();
+        RuleFor(r => r.SourcePath)
+            .NotNull();
         
-        RuleFor(r => r.DestinationFolder).NotEmpty();
-        
-        RuleFor(r => r.DestinationName).NotEmpty();
+        RuleFor(r => r.DestinationPath)
+            .NotNull();
     }
 }

--- a/src/api/MixServer.Application/FileExplorer/Commands/DeleteNode/DeleteNodeCommand.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/DeleteNode/DeleteNodeCommand.cs
@@ -4,5 +4,5 @@ namespace MixServer.Application.FileExplorer.Commands.DeleteNode;
 
 public class DeleteNodeCommand
 {
-    public required NodePathDto NodePath { get; init; }
+    public required NodePathRequestDto NodePath { get; init; }
 }

--- a/src/api/MixServer.Application/FileExplorer/Commands/DeleteNode/DeleteNodeCommand.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/DeleteNode/DeleteNodeCommand.cs
@@ -1,6 +1,8 @@
+using MixServer.Application.FileExplorer.Dtos;
+
 namespace MixServer.Application.FileExplorer.Commands.DeleteNode;
 
 public class DeleteNodeCommand
 {
-    public string AbsolutePath { get; set; } = string.Empty;
+    public required NodePathDto NodePath { get; init; }
 }

--- a/src/api/MixServer.Application/FileExplorer/Commands/DeleteNode/DeleteNodeCommandHandler.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/DeleteNode/DeleteNodeCommandHandler.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using MixServer.Application.FileExplorer.Converters;
 using MixServer.Domain.FileExplorer.Services;
 using MixServer.Domain.Interfaces;
 
@@ -6,6 +7,7 @@ namespace MixServer.Application.FileExplorer.Commands.DeleteNode;
 
 public class DeleteNodeCommandHandler(
     IFileService fileService,
+    INodePathDtoConverter nodePathDtoConverter,
     IValidator<DeleteNodeCommand> validator)
     : ICommandHandler<DeleteNodeCommand>
 {
@@ -13,6 +15,6 @@ public class DeleteNodeCommandHandler(
     {
         await validator.ValidateAndThrowAsync(request);
         
-        fileService.DeleteNode(request.AbsolutePath);
+        fileService.DeleteNode(nodePathDtoConverter.Convert(request.NodePath));
     }
 }

--- a/src/api/MixServer.Application/FileExplorer/Commands/DeleteNode/DeleteNodeCommandValidator.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/DeleteNode/DeleteNodeCommandValidator.cs
@@ -6,6 +6,7 @@ public class DeleteNodeCommandValidator : AbstractValidator<DeleteNodeCommand>
 {
     public DeleteNodeCommandValidator()
     {
-        RuleFor(r => r.AbsolutePath).NotEmpty();
+        RuleFor(r => r.NodePath)
+            .NotNull();
     }
 }

--- a/src/api/MixServer.Application/FileExplorer/Commands/RefreshFolder/RefreshFolderCommand.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/RefreshFolder/RefreshFolderCommand.cs
@@ -1,6 +1,8 @@
+using MixServer.Domain.FileExplorer.Models;
+
 namespace MixServer.Application.FileExplorer.Commands.RefreshFolder;
 
 public class RefreshFolderCommand
 {
-    public string? AbsolutePath { get; set; }
+    public NodePath? NodePath { get; set; }
 }

--- a/src/api/MixServer.Application/FileExplorer/Commands/RefreshFolder/RefreshFolderCommand.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/RefreshFolder/RefreshFolderCommand.cs
@@ -1,8 +1,8 @@
-using MixServer.Domain.FileExplorer.Models;
+using MixServer.Application.FileExplorer.Dtos;
 
 namespace MixServer.Application.FileExplorer.Commands.RefreshFolder;
 
 public class RefreshFolderCommand
 {
-    public NodePath? NodePath { get; set; }
+    public NodePathRequestDto? NodePath { get; set; }
 }

--- a/src/api/MixServer.Application/FileExplorer/Commands/RefreshFolder/RefreshFolderCommandHandler.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/RefreshFolder/RefreshFolderCommandHandler.cs
@@ -20,16 +20,16 @@ public class RefreshFolderCommandHandler(
 {
     public async Task<FileExplorerFolderResponse> HandleAsync(RefreshFolderCommand request)
     {
-        if (string.IsNullOrWhiteSpace(request.AbsolutePath))
+        if (request.NodePath is null)
         {
             rootFolder.RefreshChildren();
         }
         else
         {
-            folderCacheService.InvalidateFolder(request.AbsolutePath);
+            folderCacheService.InvalidateFolder(request.NodePath);
         }
         
-        var folder = await fileService.GetFolderOrRootAsync(request.AbsolutePath);
+        var folder = await fileService.GetFolderOrRootAsync(request.NodePath);
 
         // TODO: make a way of refreshing all users folders at once on cache invalidation with their folder sorts
         await callbackService.FolderRefreshed(

--- a/src/api/MixServer.Application/FileExplorer/Commands/RefreshFolder/RefreshFolderCommandHandler.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/RefreshFolder/RefreshFolderCommandHandler.cs
@@ -1,3 +1,4 @@
+using MixServer.Application.FileExplorer.Converters;
 using MixServer.Application.FileExplorer.Queries.GetNode;
 using MixServer.Domain.Callbacks;
 using MixServer.Domain.FileExplorer.Models;
@@ -16,20 +17,23 @@ public class RefreshFolderCommandHandler(
     IFileExplorerResponseConverter fileExplorerResponseConverter,
     IFolderCacheService folderCacheService,
     IFileService fileService,
+    INodePathDtoConverter nodePathDtoConverter,
     IRootFileExplorerFolder rootFolder) : ICommandHandler<RefreshFolderCommand, FileExplorerFolderResponse>
 {
     public async Task<FileExplorerFolderResponse> HandleAsync(RefreshFolderCommand request)
     {
-        if (request.NodePath is null)
+        var nodePath = request.NodePath is null ? null : nodePathDtoConverter.Convert(request.NodePath);
+        
+        if (nodePath is null)
         {
             rootFolder.RefreshChildren();
         }
         else
         {
-            folderCacheService.InvalidateFolder(request.NodePath);
+            folderCacheService.InvalidateFolder(nodePath);
         }
         
-        var folder = await fileService.GetFolderOrRootAsync(request.NodePath);
+        var folder = await fileService.GetFolderOrRootAsync(nodePath);
 
         // TODO: make a way of refreshing all users folders at once on cache invalidation with their folder sorts
         await callbackService.FolderRefreshed(

--- a/src/api/MixServer.Application/FileExplorer/Commands/SetFolderSort/SetFolderSortCommand.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/SetFolderSort/SetFolderSortCommand.cs
@@ -5,7 +5,7 @@ namespace MixServer.Application.FileExplorer.Commands.SetFolderSort;
 
 public class SetFolderSortCommand
 {
-    public required NodePathDto NodePath { get; set; }
+    public required NodePathRequestDto NodePath { get; set; }
 
     public bool Descending { get; set; }
 

--- a/src/api/MixServer.Application/FileExplorer/Commands/SetFolderSort/SetFolderSortCommand.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/SetFolderSort/SetFolderSortCommand.cs
@@ -1,12 +1,12 @@
+using MixServer.Application.FileExplorer.Dtos;
 using MixServer.Domain.FileExplorer.Enums;
-using MixServer.Domain.FileExplorer.Models;
 
 namespace MixServer.Application.FileExplorer.Commands.SetFolderSort;
 
-public class SetFolderSortCommand : IFolderSortRequest
+public class SetFolderSortCommand
 {
-    public string AbsoluteFolderPath { get; set; } = string.Empty;
-    
+    public required NodePathDto NodePath { get; set; }
+
     public bool Descending { get; set; }
 
     public FolderSortMode SortMode { get; set; }

--- a/src/api/MixServer.Application/FileExplorer/Commands/SetFolderSort/SetFolderSortCommandValidator.cs
+++ b/src/api/MixServer.Application/FileExplorer/Commands/SetFolderSort/SetFolderSortCommandValidator.cs
@@ -6,8 +6,8 @@ public class SetFolderSortCommandValidator : AbstractValidator<SetFolderSortComm
 {
     public SetFolderSortCommandValidator()
     {
-        RuleFor(r => r.AbsoluteFolderPath)
-            .NotEmpty();
+        RuleFor(r => r.NodePath)
+            .NotNull();
 
         RuleFor(r => r.SortMode)
             .IsInEnum();

--- a/src/api/MixServer.Application/FileExplorer/Converters/MediaInfoDtoConverter.cs
+++ b/src/api/MixServer.Application/FileExplorer/Converters/MediaInfoDtoConverter.cs
@@ -7,10 +7,9 @@ using MixServer.Domain.Interfaces;
 namespace MixServer.Application.FileExplorer.Converters;
 
 public interface IMediaInfoDtoConverter :
-    IConverter<MediaInfo, MediaInfoDto>,
-    IConverter<NodePath, NodePathDto>;
+    IConverter<MediaInfo, MediaInfoDto>;
 
-public class MediaInfoDtoConverter : IMediaInfoDtoConverter
+public class MediaInfoDtoConverter(INodePathDtoConverter nodePathDtoConverter) : IMediaInfoDtoConverter
 {
     public MediaInfoDto Convert(MediaInfo value)
     {
@@ -18,18 +17,8 @@ public class MediaInfoDtoConverter : IMediaInfoDtoConverter
         {
             Bitrate = value.Bitrate,
             Duration = FormatTimespan(value.Duration),
-            NodePath = Convert(value.NodePath),
+            NodePath = nodePathDtoConverter.Convert(value.Path),
             Tracklist = value.Tracklist
-        };
-    }
-
-    public NodePathDto Convert(NodePath value)
-    {
-        return new NodePathDto
-        {
-            ParentAbsolutePath = value.ParentAbsolutePath,
-            FileName = value.FileName,
-            AbsolutePath = value.AbsolutePath
         };
     }
     

--- a/src/api/MixServer.Application/FileExplorer/Converters/MediaInfoDtoConverter.cs
+++ b/src/api/MixServer.Application/FileExplorer/Converters/MediaInfoDtoConverter.cs
@@ -17,7 +17,7 @@ public class MediaInfoDtoConverter(INodePathDtoConverter nodePathDtoConverter) :
         {
             Bitrate = value.Bitrate,
             Duration = FormatTimespan(value.Duration),
-            NodePath = nodePathDtoConverter.Convert(value.Path),
+            NodePath = nodePathDtoConverter.ConvertToResponse(value.Path),
             Tracklist = value.Tracklist
         };
     }

--- a/src/api/MixServer.Application/FileExplorer/Converters/NodePathDtoConverter.cs
+++ b/src/api/MixServer.Application/FileExplorer/Converters/NodePathDtoConverter.cs
@@ -1,0 +1,24 @@
+using MixServer.Application.FileExplorer.Dtos;
+using MixServer.Domain.FileExplorer.Models;
+using MixServer.Domain.Interfaces;
+
+namespace MixServer.Application.FileExplorer.Converters;
+
+public interface INodePathDtoConverter : IConverter<NodePath, NodePathDto>, IConverter<NodePathDto, NodePath>;
+
+public class NodePathDtoConverter : INodePathDtoConverter
+{
+    public NodePathDto Convert(NodePath value)
+    {
+        return new NodePathDto
+        {
+            RootPath = value.RootPath,
+            RelativePath = value.RelativePath
+        };
+    }
+
+    public NodePath Convert(NodePathDto value)
+    {
+        return new NodePath(value.RootPath, value.RelativePath);
+    }
+}

--- a/src/api/MixServer.Application/FileExplorer/Converters/NodePathDtoConverter.cs
+++ b/src/api/MixServer.Application/FileExplorer/Converters/NodePathDtoConverter.cs
@@ -6,7 +6,7 @@ namespace MixServer.Application.FileExplorer.Converters;
 
 public interface INodePathDtoConverter :
     IConverter<NodePath, NodePathHeaderDto>,
-    IConverter<NodePathRequestDto, NodePath?>
+    IConverter<NodePathRequestDto, NodePath>
 {
     NodePathDto ConvertToResponse(NodePath value);
 }
@@ -23,10 +23,10 @@ public class NodePathDtoConverter : INodePathDtoConverter
         };
     }
 
-    public NodePath? Convert(NodePathRequestDto value)
+    public NodePath Convert(NodePathRequestDto value)
     {
         if (string.IsNullOrEmpty(value.RootPath) && string.IsNullOrEmpty(value.RelativePath))
-            return null;
+            return new NodePath(string.Empty, string.Empty);
 
         return new NodePath(value.RootPath ?? string.Empty, value.RelativePath ?? string.Empty);
     }

--- a/src/api/MixServer.Application/FileExplorer/Converters/NodePathDtoConverter.cs
+++ b/src/api/MixServer.Application/FileExplorer/Converters/NodePathDtoConverter.cs
@@ -4,21 +4,45 @@ using MixServer.Domain.Interfaces;
 
 namespace MixServer.Application.FileExplorer.Converters;
 
-public interface INodePathDtoConverter : IConverter<NodePath, NodePathDto>, IConverter<NodePathDto, NodePath>;
+public interface INodePathDtoConverter :
+    IConverter<NodePath, NodePathHeaderDto>,
+    IConverter<NodePathRequestDto, NodePath?>
+{
+    NodePathDto ConvertToResponse(NodePath value);
+}
 
 public class NodePathDtoConverter : INodePathDtoConverter
 {
-    public NodePathDto Convert(NodePath value)
+    public NodePathHeaderDto Convert(NodePath value)
+    {
+        return new NodePathHeaderDto
+        {
+            RootPath = value.RootPath,
+            RelativePath = value.RelativePath,
+            AbsolutePath = value.AbsolutePath
+        };
+    }
+
+    public NodePath? Convert(NodePathRequestDto value)
+    {
+        if (string.IsNullOrEmpty(value.RootPath) && string.IsNullOrEmpty(value.RelativePath))
+            return null;
+
+        return new NodePath(value.RootPath ?? string.Empty, value.RelativePath ?? string.Empty);
+    }
+
+    public NodePathDto ConvertToResponse(NodePath value)
     {
         return new NodePathDto
         {
             RootPath = value.RootPath,
-            RelativePath = value.RelativePath
+            RelativePath = value.RelativePath,
+            FileName = value.FileName,
+            AbsolutePath = value.AbsolutePath,
+            Extension = value.Extension,
+            Parent = Convert(value.Parent),
+            IsRoot = value.IsRoot,
+            IsRootChild = value.IsRootChild
         };
-    }
-
-    public NodePath Convert(NodePathDto value)
-    {
-        return new NodePath(value.RootPath, value.RelativePath);
     }
 }

--- a/src/api/MixServer.Application/FileExplorer/Dtos/NodePathDto.cs
+++ b/src/api/MixServer.Application/FileExplorer/Dtos/NodePathDto.cs
@@ -1,7 +1,16 @@
-﻿namespace MixServer.Application.FileExplorer.Dtos;
+namespace MixServer.Application.FileExplorer.Dtos;
 
-public class NodePathDto
+public class NodePathDto : NodePathRequestDto
 {
-    public required string RootPath { get; init; }
-    public required string RelativePath { get; init; }
+    public required string FileName { get; init; }
+    
+    public required string AbsolutePath { get; init; }
+    
+    public required string Extension { get; init; }
+    
+    public required NodePathHeaderDto Parent { get; init; }
+    
+    public required bool IsRoot { get; init; }
+    
+    public required bool IsRootChild { get; init; }
 }

--- a/src/api/MixServer.Application/FileExplorer/Dtos/NodePathDto.cs
+++ b/src/api/MixServer.Application/FileExplorer/Dtos/NodePathDto.cs
@@ -2,9 +2,6 @@
 
 public class NodePathDto
 {
-    public required string ParentAbsolutePath { get; init; }
-    
-    public required string FileName { get; init; }
-    
-    public required string AbsolutePath { get; init; }
+    public required string RootPath { get; init; }
+    public required string RelativePath { get; init; }
 }

--- a/src/api/MixServer.Application/FileExplorer/Dtos/NodePathHeaderDto.cs
+++ b/src/api/MixServer.Application/FileExplorer/Dtos/NodePathHeaderDto.cs
@@ -1,0 +1,6 @@
+namespace MixServer.Application.FileExplorer.Dtos;
+
+public class NodePathHeaderDto : NodePathRequestDto
+{
+    public required string AbsolutePath { get; init; }
+}

--- a/src/api/MixServer.Application/FileExplorer/Dtos/NodePathRequestDto.cs
+++ b/src/api/MixServer.Application/FileExplorer/Dtos/NodePathRequestDto.cs
@@ -1,0 +1,7 @@
+﻿namespace MixServer.Application.FileExplorer.Dtos;
+
+public class NodePathRequestDto
+{
+    public string? RootPath { get; set; }
+    public string? RelativePath { get; set; }
+}

--- a/src/api/MixServer.Application/FileExplorer/Queries/GetNode/FileExplorerNodeResponse.cs
+++ b/src/api/MixServer.Application/FileExplorer/Queries/GetNode/FileExplorerNodeResponse.cs
@@ -12,25 +12,23 @@ namespace MixServer.Application.FileExplorer.Queries.GetNode;
 [JsonConverter(typeof(JsonInheritanceConverter), "discriminator")]
 public class FileExplorerNodeResponse
 {
-    public string Name { get; init; } = string.Empty;
+    public required NodePathDto Path { get; init; }
 
-    public string AbsolutePath { get; init; } = string.Empty;
+    public required FileExplorerNodeType Type { get; init; }
 
-    public FileExplorerNodeType Type { get; init; }
-
-    public bool Exists { get; init; }
+    public required bool Exists { get; init; }
     
-    public DateTime CreationTimeUtc { get; init; }
+    public required DateTime CreationTimeUtc { get; init; }
     
     [UsedImplicitly]
     public static IEnumerable<Type> GetKnownTypes()
     {
-        return new[]
-        {
+        return
+        [
             typeof(FileExplorerNodeResponse),
             typeof(FileExplorerFileNodeResponse),
-            typeof(FileExplorerFolderNodeResponse),
-        };
+            typeof(FileExplorerFolderNodeResponse)
+        ];
     }
 }
 
@@ -45,31 +43,31 @@ public class FileExplorerFileNodeResponse : FileExplorerNodeResponse
 
 public class FileExplorerFolderNodeResponse : FileExplorerNodeResponse
 {
-    public bool BelongsToRoot { get; init; }
+    public required bool BelongsToRoot { get; init; }
 
-    public bool BelongsToRootChild { get; init; }
+    public required bool BelongsToRootChild { get; init; }
     
-    public FileExplorerFolderNodeResponse? Parent { get; init; }
+    public required FileExplorerFolderNodeResponse? Parent { get; init; }
 }
 
 [KnownType(nameof(GetKnownTypes))]
 [JsonConverter(typeof(JsonInheritanceConverter), "discriminator")]
 public class FileExplorerFolderResponse
 {
-    public FileExplorerFolderNodeResponse Node { get; init; } = new ();
+    public required FileExplorerFolderNodeResponse Node { get; init; }
 
-    public IReadOnlyCollection<FileExplorerNodeResponse> Children { get; init; } = Array.Empty<FileExplorerNodeResponse>();
+    public IReadOnlyCollection<FileExplorerNodeResponse> Children { get; init; } = [];
 
     public FolderSortDto Sort { get; set; } = FolderSortDto.Default;
     
     [UsedImplicitly]
     public static IEnumerable<Type> GetKnownTypes()
     {
-        return new[]
-        {
+        return
+        [
             typeof(FileExplorerFolderResponse),
             typeof(RootFileExplorerFolderResponse)
-        };
+        ];
     }
 }
 

--- a/src/api/MixServer.Application/FileExplorer/Queries/GetNode/FileExplorerResponseConverter.cs
+++ b/src/api/MixServer.Application/FileExplorer/Queries/GetNode/FileExplorerResponseConverter.cs
@@ -21,6 +21,7 @@ public interface IFileExplorerResponseConverter
 public class FileExplorerResponseConverter(
     IMediaInfoCache mediaInfoCache,
     IMediaInfoDtoConverter mediaInfoDtoConverter,
+    INodePathDtoConverter nodePathDtoConverter,
     ITranscodeCache transcodeCache) : IFileExplorerResponseConverter
 {
     public FileExplorerNodeResponse Convert(IFileExplorerNode value)
@@ -37,12 +38,11 @@ public class FileExplorerResponseConverter(
     {
         return new FileExplorerFileNodeResponse
         {
-            AbsolutePath = value.AbsolutePath,
+            Path = nodePathDtoConverter.Convert(value.Path),
             Exists = value.Exists,
-            Name = value.Name,
             Type = value.Type,
             CreationTimeUtc = value.CreationTimeUtc,
-            Metadata = Convert(value.Metadata, value.AbsolutePath),
+            Metadata = Convert(value.Metadata, value.Path),
             PlaybackSupported = value.PlaybackSupported,
             Parent = Convert(value.Parent)
         };
@@ -52,9 +52,8 @@ public class FileExplorerResponseConverter(
     {
         return new FileExplorerFolderNodeResponse
         {
-            AbsolutePath = value.AbsolutePath,
+            Path = nodePathDtoConverter.Convert(value.Path),
             Exists = value.Exists,
-            Name = value.Name,
             Type = value.Type,
             CreationTimeUtc = value.CreationTimeUtc,
             BelongsToRoot = value.BelongsToRoot,
@@ -87,17 +86,17 @@ public class FileExplorerResponseConverter(
         };
     }
 
-    private FileMetadataResponse Convert(IFileMetadata value, string absolutePath)
+    private FileMetadataResponse Convert(IFileMetadata value, NodePath nodePath)
     {
         return new FileMetadataResponse
         {
-            MediaInfo = value.IsMedia && mediaInfoCache.TryGet(absolutePath, out var mediaInfo)
+            MediaInfo = value.IsMedia && mediaInfoCache.TryGet(nodePath, out var mediaInfo)
                 ? mediaInfoDtoConverter.Convert(mediaInfo)
                 : null,
             IsMedia = value.IsMedia,
             MimeType = value.MimeType,
             TranscodeStatus = value.IsMedia
-                ? transcodeCache.GetTranscodeStatus(absolutePath)
+                ? transcodeCache.GetTranscodeStatus(nodePath)
                 : TranscodeState.None
         };
     }

--- a/src/api/MixServer.Application/FileExplorer/Queries/GetNode/FileExplorerResponseConverter.cs
+++ b/src/api/MixServer.Application/FileExplorer/Queries/GetNode/FileExplorerResponseConverter.cs
@@ -38,7 +38,7 @@ public class FileExplorerResponseConverter(
     {
         return new FileExplorerFileNodeResponse
         {
-            Path = nodePathDtoConverter.Convert(value.Path),
+            Path = nodePathDtoConverter.ConvertToResponse(value.Path),
             Exists = value.Exists,
             Type = value.Type,
             CreationTimeUtc = value.CreationTimeUtc,
@@ -52,7 +52,7 @@ public class FileExplorerResponseConverter(
     {
         return new FileExplorerFolderNodeResponse
         {
-            Path = nodePathDtoConverter.Convert(value.Path),
+            Path = nodePathDtoConverter.ConvertToResponse(value.Path),
             Exists = value.Exists,
             Type = value.Type,
             CreationTimeUtc = value.CreationTimeUtc,

--- a/src/api/MixServer.Application/FileExplorer/Queries/GetNode/GetFolderNodeQuery.cs
+++ b/src/api/MixServer.Application/FileExplorer/Queries/GetNode/GetFolderNodeQuery.cs
@@ -1,6 +1,8 @@
+using MixServer.Application.FileExplorer.Dtos;
+
 namespace MixServer.Application.FileExplorer.Queries.GetNode;
 
 public class GetFolderNodeQuery
 {
-    public string? AbsolutePath { get; set; }
+    public NodePathDto? NodePath { get; set; }
 }

--- a/src/api/MixServer.Application/FileExplorer/Queries/GetNode/GetFolderNodeQuery.cs
+++ b/src/api/MixServer.Application/FileExplorer/Queries/GetNode/GetFolderNodeQuery.cs
@@ -4,5 +4,5 @@ namespace MixServer.Application.FileExplorer.Queries.GetNode;
 
 public class GetFolderNodeQuery
 {
-    public NodePathDto? NodePath { get; set; }
+    public NodePathRequestDto? NodePath { get; set; }
 }

--- a/src/api/MixServer.Application/FileExplorer/Queries/GetNode/GetFolderNodeQueryHandler.cs
+++ b/src/api/MixServer.Application/FileExplorer/Queries/GetNode/GetFolderNodeQueryHandler.cs
@@ -1,3 +1,4 @@
+using MixServer.Application.FileExplorer.Converters;
 using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.FileExplorer.Services;
 using MixServer.Domain.Interfaces;
@@ -6,12 +7,16 @@ namespace MixServer.Application.FileExplorer.Queries.GetNode;
 
 public class GetFolderNodeQueryHandler(
     IConverter<IFileExplorerFolder, FileExplorerFolderResponse> folderNodeConverter,
+    INodePathDtoConverter nodePathConverter,
     IFileService fileService)
     : IQueryHandler<GetFolderNodeQuery, FileExplorerFolderResponse>
 {
     public async Task<FileExplorerFolderResponse> HandleAsync(GetFolderNodeQuery request)
     {
-        var folder = await fileService.GetFolderOrRootAsync(request.AbsolutePath);
+        var folder = await fileService.GetFolderOrRootAsync(
+            request.NodePath is null
+                ? null
+                : nodePathConverter.Convert(request.NodePath));
 
         var result = folderNodeConverter.Convert(folder);
 

--- a/src/api/MixServer.Application/FileExplorer/Queries/GetNode/GetFolderNodeQueryHandler.cs
+++ b/src/api/MixServer.Application/FileExplorer/Queries/GetNode/GetFolderNodeQueryHandler.cs
@@ -1,4 +1,5 @@
 using MixServer.Application.FileExplorer.Converters;
+using MixServer.Application.FileExplorer.Dtos;
 using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.FileExplorer.Services;
 using MixServer.Domain.Interfaces;
@@ -9,14 +10,11 @@ public class GetFolderNodeQueryHandler(
     IConverter<IFileExplorerFolder, FileExplorerFolderResponse> folderNodeConverter,
     INodePathDtoConverter nodePathConverter,
     IFileService fileService)
-    : IQueryHandler<GetFolderNodeQuery, FileExplorerFolderResponse>
+    : IQueryHandler<NodePathRequestDto, FileExplorerFolderResponse>
 {
-    public async Task<FileExplorerFolderResponse> HandleAsync(GetFolderNodeQuery request)
+    public async Task<FileExplorerFolderResponse> HandleAsync(NodePathRequestDto request)
     {
-        var folder = await fileService.GetFolderOrRootAsync(
-            request.NodePath is null
-                ? null
-                : nodePathConverter.Convert(request.NodePath));
+        var folder = await fileService.GetFolderOrRootAsync(nodePathConverter.Convert(request));
 
         var result = folderNodeConverter.Convert(folder);
 

--- a/src/api/MixServer.Application/Queueing/Commands/AddToQueue/AddToQueueCommand.cs
+++ b/src/api/MixServer.Application/Queueing/Commands/AddToQueue/AddToQueueCommand.cs
@@ -1,8 +1,8 @@
-﻿namespace MixServer.Application.Queueing.Commands.AddToQueue;
+﻿using MixServer.Application.FileExplorer.Dtos;
+
+namespace MixServer.Application.Queueing.Commands.AddToQueue;
 
 public class AddToQueueCommand
 {
-    public string AbsoluteFolderPath { get; set; } = string.Empty;
-
-    public string FileName { get; set; } = string.Empty;
+    public required NodePathDto NodePath { get; init; }
 }

--- a/src/api/MixServer.Application/Queueing/Commands/AddToQueue/AddToQueueCommand.cs
+++ b/src/api/MixServer.Application/Queueing/Commands/AddToQueue/AddToQueueCommand.cs
@@ -4,5 +4,5 @@ namespace MixServer.Application.Queueing.Commands.AddToQueue;
 
 public class AddToQueueCommand
 {
-    public required NodePathDto NodePath { get; init; }
+    public required NodePathRequestDto NodePath { get; init; }
 }

--- a/src/api/MixServer.Application/Queueing/Commands/AddToQueue/AddToQueueCommandHandler.cs
+++ b/src/api/MixServer.Application/Queueing/Commands/AddToQueue/AddToQueueCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using MixServer.Application.FileExplorer.Converters;
 using MixServer.Application.Queueing.Responses;
 using MixServer.Domain.FileExplorer.Services;
 using MixServer.Domain.Interfaces;
@@ -11,6 +12,7 @@ public class AddToQueueCommandHandler(
     IConverter<QueueSnapshot, QueueSnapshotDto> converter,
     IFileService fileService,
     IQueueService queueService,
+    INodePathDtoConverter nodePathDtoConverter,
     IValidator<AddToQueueCommand> validator)
     : ICommandHandler<AddToQueueCommand, QueueSnapshotDto>
 {
@@ -18,7 +20,7 @@ public class AddToQueueCommandHandler(
     {
         await validator.ValidateAndThrowAsync(request);
 
-        var file = fileService.GetFile(request.AbsoluteFolderPath, request.FileName);
+        var file = fileService.GetFile(nodePathDtoConverter.Convert(request.NodePath));
 
         var queueSnapshot = await queueService.AddToQueueAsync(file);
 

--- a/src/api/MixServer.Application/Queueing/Commands/AddToQueue/AddToQueueCommandValidator.cs
+++ b/src/api/MixServer.Application/Queueing/Commands/AddToQueue/AddToQueueCommandValidator.cs
@@ -6,10 +6,7 @@ public class AddToQueueCommandValidator : AbstractValidator<AddToQueueCommand>
 {
     public AddToQueueCommandValidator()
     {
-        RuleFor(r => r.FileName)
-            .NotEmpty();
-
-        RuleFor(r => r.AbsoluteFolderPath)
+        RuleFor(r => r.NodePath)
             .NotEmpty();
     }
 }

--- a/src/api/MixServer.Application/Queueing/Commands/SetQueuePosition/SetQueuePositionCommandHandler.cs
+++ b/src/api/MixServer.Application/Queueing/Commands/SetQueuePosition/SetQueuePositionCommandHandler.cs
@@ -27,8 +27,7 @@ public class SetQueuePositionCommandHandler(
         
         var session = await sessionService.AddOrUpdateSessionAsync(new AddOrUpdateSessionRequest
         {
-            ParentAbsoluteFilePath = file.Parent.AbsolutePath,
-            FileName = file.Name
+            NodePath = file.Path
         });
 
         await unitOfWork.SaveChangesAsync();

--- a/src/api/MixServer.Application/Sessions/Commands/RequestPlayback/RequestPlaybackCommandHandler.cs
+++ b/src/api/MixServer.Application/Sessions/Commands/RequestPlayback/RequestPlaybackCommandHandler.cs
@@ -34,7 +34,13 @@ public class RequestPlaybackCommandHandler(
         var requestDeviceId = request.DeviceId ?? currentDeviceRepository.DeviceId;
         
         var deviceState = deviceTrackingService.GetDeviceStateOrThrow(requestDeviceId);
-        var file = folderCacheService.GetFile(playbackState.AbsolutePath);
+
+        if (playbackState.NodePath is null)
+        {
+            throw new InvalidRequestException(nameof(playbackState.NodePath), "Playback file state is not set");
+        }
+
+        var file = folderCacheService.GetFile(playbackState.NodePath);
 
         canPlayOnDeviceValidator.ValidateCanPlayOrThrow(deviceState, file);
 

--- a/src/api/MixServer.Application/Sessions/Commands/SetCurrentSession/SetCurrentSessionCommand.cs
+++ b/src/api/MixServer.Application/Sessions/Commands/SetCurrentSession/SetCurrentSessionCommand.cs
@@ -1,8 +1,8 @@
-﻿namespace MixServer.Application.Sessions.Commands.SetCurrentSession;
+﻿using MixServer.Application.FileExplorer.Dtos;
+
+namespace MixServer.Application.Sessions.Commands.SetCurrentSession;
 
 public class SetCurrentSessionCommand
 {
-    public string AbsoluteFolderPath { get; set; } = string.Empty;
-
-    public string FileName { get; set; } = string.Empty;
+    public required NodePathDto NodePath { get; init; }
 }

--- a/src/api/MixServer.Application/Sessions/Commands/SetCurrentSession/SetCurrentSessionCommand.cs
+++ b/src/api/MixServer.Application/Sessions/Commands/SetCurrentSession/SetCurrentSessionCommand.cs
@@ -4,5 +4,5 @@ namespace MixServer.Application.Sessions.Commands.SetCurrentSession;
 
 public class SetCurrentSessionCommand
 {
-    public required NodePathDto NodePath { get; init; }
+    public required NodePathRequestDto NodePath { get; init; }
 }

--- a/src/api/MixServer.Application/Sessions/Commands/SetCurrentSession/SetCurrentSessionCommandHandler.cs
+++ b/src/api/MixServer.Application/Sessions/Commands/SetCurrentSession/SetCurrentSessionCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using MixServer.Application.FileExplorer.Converters;
 using MixServer.Application.Sessions.Converters;
 using MixServer.Application.Sessions.Dtos;
 using MixServer.Domain.Interfaces;
@@ -13,6 +14,7 @@ namespace MixServer.Application.Sessions.Commands.SetCurrentSession;
 
 public class SetCurrentSessionCommandHandler(
     IPlaybackSessionDtoConverter converter,
+    INodePathDtoConverter nodePathDtoConverter,
     IQueueService queueService,
     ISessionService sessionService,
     IUnitOfWork unitOfWork,
@@ -25,8 +27,7 @@ public class SetCurrentSessionCommandHandler(
 
         var nextSession = await sessionService.AddOrUpdateSessionAsync(new AddOrUpdateSessionRequest
         {
-            ParentAbsoluteFilePath = request.AbsoluteFolderPath,
-            FileName = request.FileName
+            NodePath = nodePathDtoConverter.Convert(request.NodePath)
         });
 
         var queueSnapshot = await queueService.SetQueueFolderAsync(nextSession);

--- a/src/api/MixServer.Application/Sessions/Commands/SetCurrentSession/SetCurrentSessionCommandValidator.cs
+++ b/src/api/MixServer.Application/Sessions/Commands/SetCurrentSession/SetCurrentSessionCommandValidator.cs
@@ -6,14 +6,13 @@ public class SetCurrentSessionCommandValidator : AbstractValidator<SetCurrentSes
 {
     public SetCurrentSessionCommandValidator()
     {
-        RuleFor(r => r.AbsoluteFolderPath)
-            .NotEmpty()
-            .Must(Directory.Exists);
+        RuleFor(r => r.NodePath.RelativePath)
+            .NotEmpty();
 
-        RuleFor(r => r.FileName)
+        RuleFor(r => r.NodePath.RootPath)
             .NotEmpty();
         
         RuleFor(r => r)
-            .Must(m => File.Exists(Path.Join(m.AbsoluteFolderPath, m.FileName)));
+            .Must(m => File.Exists(Path.Join(m.NodePath.RootPath, m.NodePath.RelativePath)));
     }
 }

--- a/src/api/MixServer.Application/Sessions/Commands/SetNextSession/SetNextSessionCommandHandler.cs
+++ b/src/api/MixServer.Application/Sessions/Commands/SetNextSession/SetNextSessionCommandHandler.cs
@@ -58,8 +58,7 @@ public class SetNextSessionCommandHandler(
             ? null
             : await sessionService.AddOrUpdateSessionAsync(new AddOrUpdateSessionRequest
             {
-                ParentAbsoluteFilePath = nextFile.Parent.AbsolutePath,
-                FileName = nextFile.Name
+                NodePath = nextFile.Path
             });
         
         await unitOfWork.SaveChangesAsync();

--- a/src/api/MixServer.Application/Streams/Commands/RequestTranscode/RequestTranscodeCommand.cs
+++ b/src/api/MixServer.Application/Streams/Commands/RequestTranscode/RequestTranscodeCommand.cs
@@ -4,5 +4,5 @@ namespace MixServer.Application.Streams.Commands.RequestTranscode;
 
 public class RequestTranscodeCommand
 {
-    public required NodePathDto NodePath { get; init; }
+    public required NodePathRequestDto NodePath { get; init; }
 }

--- a/src/api/MixServer.Application/Streams/Commands/RequestTranscode/RequestTranscodeCommand.cs
+++ b/src/api/MixServer.Application/Streams/Commands/RequestTranscode/RequestTranscodeCommand.cs
@@ -1,6 +1,8 @@
+using MixServer.Application.FileExplorer.Dtos;
+
 namespace MixServer.Application.Streams.Commands.RequestTranscode;
 
 public class RequestTranscodeCommand
 {
-    public string AbsoluteFilePath { get; set; } = string.Empty;
+    public required NodePathDto NodePath { get; init; }
 }

--- a/src/api/MixServer.Application/Streams/Commands/RequestTranscode/RequestTranscodeCommandHandler.cs
+++ b/src/api/MixServer.Application/Streams/Commands/RequestTranscode/RequestTranscodeCommandHandler.cs
@@ -12,7 +12,7 @@ using MixServer.Domain.Streams.Services;
 namespace MixServer.Application.Streams.Commands.RequestTranscode;
 
 public class RequestTranscodeCommandHandler(
-    IFileService fileService,
+    IFolderPersistenceService folderPersistenceService,
     IMediaInfoCache mediaInfoCache,
     INodePathDtoConverter nodePathDtoConverter,
     ITranscodeService transcodeService,
@@ -27,7 +27,7 @@ public class RequestTranscodeCommandHandler(
         
         var nodePath = nodePathDtoConverter.Convert(request.NodePath);
         
-        var file = fileService.GetFile(nodePath);
+        var file = await folderPersistenceService.GetFileAsync(nodePath);
 
         if (!file.Exists)
         {
@@ -47,6 +47,6 @@ public class RequestTranscodeCommandHandler(
         }
         
         var bitrate = mediaInfoCache.TryGet(file.Path, out var mediaInfo) ? mediaInfo.Bitrate : 0;
-        await transcodeService.RequestTranscodeAsync(file.Path, bitrate);
+        await transcodeService.RequestTranscodeAsync(file.Entity, bitrate);
     }
 }

--- a/src/api/MixServer.Application/Streams/Commands/RequestTranscode/RequestTranscodeCommandValidator.cs
+++ b/src/api/MixServer.Application/Streams/Commands/RequestTranscode/RequestTranscodeCommandValidator.cs
@@ -6,6 +6,6 @@ public class RequestTranscodeCommandValidator : AbstractValidator<RequestTransco
 {
     public RequestTranscodeCommandValidator()
     {
-        RuleFor(x => x.AbsoluteFilePath).NotEmpty();
+        RuleFor(x => x.NodePath).NotNull();
     }
 }

--- a/src/api/MixServer.Application/Streams/Queries/GetStream/GetStreamQueryHandler.cs
+++ b/src/api/MixServer.Application/Streams/Queries/GetStream/GetStreamQueryHandler.cs
@@ -1,6 +1,5 @@
 ﻿using FluentValidation;
 using MixServer.Domain.Exceptions;
-using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.FileExplorer.Services;
 using MixServer.Domain.Interfaces;
 using MixServer.Domain.Sessions.Accessors;
@@ -22,7 +21,6 @@ public class GetStreamQueryHandler(
     ISessionService sessionService,
     ITranscodeCache transcodeCache,
     ITranscodeRepository transcodeRepository,
-    IRootFileExplorerFolder rootFileExplorerFolder,
     IValidator<GetStreamQuery> validator)
     : IQueryHandler<GetStreamQuery, StreamFile>
 {
@@ -55,7 +53,7 @@ public class GetStreamQueryHandler(
 
         if (session.File is null || !session.File.Exists)
         {
-            throw new NotFoundException(nameof(PlaybackSession), session.AbsolutePath);
+            throw new NotFoundException(nameof(PlaybackSession), session.NodeEntity.Path.AbsolutePath);
         }
 
         var transcode = await transcodeRepository.GetOrDefaultAsync(session.File.Path);
@@ -75,12 +73,10 @@ public class GetStreamQueryHandler(
         }
 
         var mimeType = mimeTypeService.GetMimeType(session.File.Path);
-
-        var filePath = rootFileExplorerFolder.GetNodePath(session.AbsolutePath);
         
         return new DirectStreamFile(mimeType)
         {
-            FilePath = filePath
+            FilePath = session.NodeEntity.Path
         };
     }
 }

--- a/src/api/MixServer.Application/Streams/Queries/GetStream/GetStreamQueryHandler.cs
+++ b/src/api/MixServer.Application/Streams/Queries/GetStream/GetStreamQueryHandler.cs
@@ -7,6 +7,7 @@ using MixServer.Domain.Sessions.Accessors;
 using MixServer.Domain.Sessions.Entities;
 using MixServer.Domain.Sessions.Services;
 using MixServer.Domain.Streams.Caches;
+using MixServer.Domain.Streams.Entities;
 using MixServer.Domain.Streams.Models;
 using MixServer.Domain.Streams.Repositories;
 using MixServer.Domain.Users.Services;
@@ -57,12 +58,19 @@ public class GetStreamQueryHandler(
             throw new NotFoundException(nameof(PlaybackSession), session.AbsolutePath);
         }
 
+        var transcode = await transcodeRepository.GetOrDefaultAsync(session.File.Path);
         // Specifically use the RequestDevice to determine if the file can be played
         // Because if playback device is switched we want the client to be seeing what version they can play
         // Rather than what the playback device can play e.g. switching from Transcode to DirectStream
-        if (!deviceTrackingService.GetDeviceStateOrThrow(securityParameters.DeviceId).CanPlay(session.File))
+        var canPlayDirect = deviceTrackingService.GetDeviceStateOrThrow(securityParameters.DeviceId).CanPlay(session.File);
+        
+        if (transcode is not null || !canPlayDirect)
         {
-            var transcode = await transcodeRepository.GetAsync(session.File.Path);
+            if (transcode is null)
+            {
+                throw new NotFoundException(nameof(Transcode), session.File.Path.AbsolutePath);
+            }
+            
             return transcodeCache.GetPlaylistOrThrowAsync(transcode.Id);
         }
 

--- a/src/api/MixServer.Application/Tracklists/Commands/SaveTracklist/SaveTracklistCommandHandler.cs
+++ b/src/api/MixServer.Application/Tracklists/Commands/SaveTracklist/SaveTracklistCommandHandler.cs
@@ -23,7 +23,7 @@ public class SaveTracklistCommandHandler(
             throw new InvalidRequestException("CurrentPlaybackSession", "No playback session is currently active.");
         }
 
-        var currentSessionFilePath = currentUserRepository.CurrentUser.CurrentPlaybackSession.AbsolutePath;
+        var currentSessionFilePath = currentUserRepository.CurrentUser.CurrentPlaybackSession.NodeEntity.Path.AbsolutePath;
 
         if (!File.Exists(currentSessionFilePath))
         {

--- a/src/api/MixServer.Domain/Callbacks/ICallbackService.cs
+++ b/src/api/MixServer.Domain/Callbacks/ICallbackService.cs
@@ -29,8 +29,8 @@ public interface ICallbackService
     Task UserDeleted(string userId);
     Task UserAdded(IUser user);
     Task UserUpdated(IUser user);
-    Task FileExplorerNodeUpdated(Dictionary<string, int> expectedNodeIndexes, IFileExplorerNode node, string? oldAbsolutePath);
-    Task FileExplorerNodeDeleted(IFileExplorerFolderNode parentNode, string absolutePath);
+    Task FileExplorerNodeUpdated(Dictionary<string, int> expectedNodeIndexes, IFileExplorerNode node, NodePath? oldPath);
+    Task FileExplorerNodeDeleted(IFileExplorerFolderNode parentNode, NodePath path);
     Task MediaInfoUpdated(IReadOnlyCollection<MediaInfo> mediaInfo);
     Task MediaInfoRemoved(IReadOnlyCollection<NodePath> removedItems);
 }

--- a/src/api/MixServer.Domain/Extensions/ServiceCollectionExtensions.cs
+++ b/src/api/MixServer.Domain/Extensions/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddScoped<IUserValidator, UserValidator>();
         services.AddSingleton<IFolderCacheService, FolderCacheService>();
+        services.AddTransient<IFolderPersistenceService, FolderPersistenceService>();
         services.AddSingleton<IFileNotificationService, FileNotificationService>();
         services.AddTransient<FileExplorerConverter, FileExplorerConverter>();
         services.AddSingleton<IRootFileExplorerFolder, RootFileExplorerFolder>();

--- a/src/api/MixServer.Domain/FileExplorer/Converters/FileExplorerConverter.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Converters/FileExplorerConverter.cs
@@ -53,7 +53,7 @@ public class FileExplorerConverter(
             directoryInfo.Exists,
             directoryInfo.CreationTimeUtc,
             nodePath.IsRoot,
-            nodePath.IsRootChild,
+            rootFolder.DescendantOfRoot(nodePath),
             parent);
     }
 

--- a/src/api/MixServer.Domain/FileExplorer/Converters/FileExplorerConverter.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Converters/FileExplorerConverter.cs
@@ -32,25 +32,28 @@ public class FileExplorerConverter(
     
     private FileExplorerFolderNode Convert(DirectoryInfo directoryInfo, bool includeParent)
     {
-        var currentFolderBelongsToRoot = rootFolder.BelongsToRoot(directoryInfo.FullName);
+        var nodePath = rootFolder.GetNodePath(directoryInfo.FullName);
 
         IFileExplorerFolderNode? parent = null;
-        if (includeParent && directoryInfo.Parent is not null)
+        if (includeParent && !nodePath.IsRoot)
         {
-            parent = currentFolderBelongsToRoot
-                ? rootFolder.Node
-                : Convert(directoryInfo.Parent, false);
+            if (nodePath.IsRootChild)
+            {
+                parent = rootFolder.Node;
+            }
+            else if (directoryInfo.Parent is not null)
+            {
+                parent = Convert(directoryInfo.Parent, false);
+            }
         }
         
-        var path = rootFolder.GetNodePath(directoryInfo.FullName);
-        
         return new FileExplorerFolderNode(
-            path,
+            nodePath,
             FileExplorerNodeType.Folder,
             directoryInfo.Exists,
             directoryInfo.CreationTimeUtc,
-            currentFolderBelongsToRoot,
-            rootFolder.BelongsToRootChild(directoryInfo.FullName),
+            nodePath.IsRoot,
+            nodePath.IsRootChild,
             parent);
     }
 

--- a/src/api/MixServer.Domain/FileExplorer/Converters/FileMetadataConverter.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Converters/FileMetadataConverter.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.FileExplorer.Models.Metadata;
 using MixServer.Domain.FileExplorer.Services;
 using MixServer.Domain.Interfaces;
@@ -13,10 +14,8 @@ namespace MixServer.Domain.FileExplorer.Converters;
 public interface IFileMetadataConverter : IConverter<FileInfo, IFileMetadata>;
 
 public partial class FileMetadataConverter(
-    ILogger<FileMetadataConverter> logger,
-    ITagBuilderFactory tagBuilderFactory,
-    ITracklistTagService tracklistTagService,
-    IMimeTypeService mimeTypeService)
+    IMimeTypeService mimeTypeService,
+    IRootFileExplorerFolder rootFileExplorerFolder)
     : IFileMetadataConverter
 {
     private static readonly HashSet<string> ExcludedMediaMimeTypes =
@@ -26,7 +25,9 @@ public partial class FileMetadataConverter(
     
     public IFileMetadata Convert(FileInfo file)
     {
-        var mimeType = mimeTypeService.GetMimeType(file.FullName, file.Extension);
+        var nodePath = rootFileExplorerFolder.GetNodePath(file.FullName);
+        
+        var mimeType = mimeTypeService.GetMimeType(nodePath);
 
         var isMedia = !string.IsNullOrWhiteSpace(mimeType) &&
                       AudioVideoMimeTypeRegex().IsMatch(mimeType) &&

--- a/src/api/MixServer.Domain/FileExplorer/Entities/FileExplorerNodeEntityBase.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Entities/FileExplorerNodeEntityBase.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using MixServer.Domain.FileExplorer.Enums;
+using MixServer.Domain.FileExplorer.Models;
+using MixServer.Domain.Streams.Entities;
+
+namespace MixServer.Domain.FileExplorer.Entities;
+
+public class FileExplorerNodeEntityBase
+{
+    public required Guid Id { get; init; }
+    
+    public required string RelativePath { get; set; }
+    
+    public FileExplorerEntityNodeType NodeType { get; init; }
+}
+
+public class FileExplorerRootChildNodeEntity : FileExplorerNodeEntityBase;
+
+public class FileExplorerNodeEntity : FileExplorerNodeEntityBase
+{
+    public required FileExplorerRootChildNodeEntity RootChild { get; set; }
+    
+    public Guid RootChildId { get; set; }
+    
+    [NotMapped]
+    public NodePath Path => new(RootChild.RelativePath, RelativePath);
+}
+
+public class FileExplorerFileNodeEntity : FileExplorerNodeEntity
+{
+    public Transcode? Transcode { get; set; }
+}
+
+public class FileExplorerFolderNodeEntity : FileExplorerNodeEntity;

--- a/src/api/MixServer.Domain/FileExplorer/Entities/FolderSort.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Entities/FolderSort.cs
@@ -3,7 +3,7 @@ using MixServer.Domain.FileExplorer.Models;
 
 namespace MixServer.Domain.FileExplorer.Entities;
 
-public class FolderSort : IFolderSortRequest
+public class FolderSort : IFolderSort
 {
     public FolderSort(
         Guid id,

--- a/src/api/MixServer.Domain/FileExplorer/Entities/FolderSort.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Entities/FolderSort.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations.Schema;
 using MixServer.Domain.FileExplorer.Enums;
 using MixServer.Domain.FileExplorer.Models;
 
@@ -5,31 +6,34 @@ namespace MixServer.Domain.FileExplorer.Entities;
 
 public class FolderSort : IFolderSort
 {
-    public FolderSort(
-        Guid id,
-        string absoluteFolderPath,
-        bool descending,
-        FolderSortMode sortMode)
-    {
-        Id = id;
-        AbsoluteFolderPath = absoluteFolderPath;
-        Descending = descending;
-        SortMode = sortMode;
-    }
+    public required Guid Id { get; init; }
+    
+    // TODO: Make this non-nullable after migration to new root, relative paths is complete.
+    public FileExplorerFolderNodeEntity? Node { get; set; }
+    public Guid? NodeId { get; set; }
 
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-    protected FolderSort()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    [Obsolete("Use Node instead.")]
+    public string AbsoluteFolderPath { get; set; } = string.Empty;
+    public required bool Descending { get; set; }
+    public required FolderSortMode SortMode { get; set;  }
+
+    public required string UserId { get; set; } 
+
+    // Workaround for application code to pretend Node is not nullable
+    [NotMapped]
+    public required FileExplorerFolderNodeEntity NodeEntity
     {
+        get => Node ?? throw new InvalidOperationException("Node is not set.");
+        set => Node = value;
     }
     
-    public Guid Id { get; protected set; }
-    public string AbsoluteFolderPath { get; protected set; }
-    public bool Descending { get; protected set; }
-    public FolderSortMode SortMode { get; protected set;  }
-
-    public string UserId { get; set; } = string.Empty;
-
+    [NotMapped]
+    public required Guid NodeIdEntity
+    {
+        get => NodeId ?? throw new InvalidOperationException("NodeId is not set.");
+        set => NodeId = value;
+    }
+    
     public void Update(IFolderSort updatedSort)
     {
         Descending = updatedSort.Descending;

--- a/src/api/MixServer.Domain/FileExplorer/Enums/FileExplorerEntityNodeType.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Enums/FileExplorerEntityNodeType.cs
@@ -1,0 +1,10 @@
+namespace MixServer.Domain.FileExplorer.Enums;
+
+public enum FileExplorerEntityNodeType
+{
+    Base,
+    Node,
+    File,
+    Folder,
+    RootChild
+}

--- a/src/api/MixServer.Domain/FileExplorer/Models/Caching/FolderCacheServiceItemRemovedEventArgs.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/Caching/FolderCacheServiceItemRemovedEventArgs.cs
@@ -1,8 +1,8 @@
 namespace MixServer.Domain.FileExplorer.Models.Caching;
 
-public class FolderCacheServiceItemRemovedEventArgs(IFileExplorerFolderNode parent, string fullName)
+public class FolderCacheServiceItemRemovedEventArgs : EventArgs
 {
-    public string FullName { get; } = fullName;
+    public required NodePath Path { get; init; }
     
-    public IFileExplorerFolderNode Parent { get; } = parent;
+    public required IFileExplorerFolderNode Parent { get; init; }
 }

--- a/src/api/MixServer.Domain/FileExplorer/Models/Caching/FolderCacheServiceItemUpdatedEventArgs.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/Caching/FolderCacheServiceItemUpdatedEventArgs.cs
@@ -1,7 +1,7 @@
 namespace MixServer.Domain.FileExplorer.Models.Caching;
 
-public class FolderCacheServiceItemUpdatedEventArgs(IFileExplorerNode item, string oldFullName)
+public class FolderCacheServiceItemUpdatedEventArgs
 {
-    public IFileExplorerNode Item { get; } = item;
-    public string OldFullName { get; } = oldFullName;
+    public required IFileExplorerNode Item { get; init; }
+    public required NodePath OldPath { get; init; }
 }

--- a/src/api/MixServer.Domain/FileExplorer/Models/Caching/FolderItemUpdatedEventArgs.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/Caching/FolderItemUpdatedEventArgs.cs
@@ -1,8 +1,8 @@
 namespace MixServer.Domain.FileExplorer.Models.Caching;
 
-public class FolderItemUpdatedEventArgs(IFileExplorerNode item, string oldFullPath)
+public class FolderItemUpdatedEventArgs(IFileExplorerNode item, NodePath oldPath)
 {
     public IFileExplorerNode Item { get; } = item;
 
-    public string OldFullPath { get; } = oldFullPath;
+    public NodePath OldPath { get; } = oldPath;
 }

--- a/src/api/MixServer.Domain/FileExplorer/Models/FileExplorerFileNode.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/FileExplorerFileNode.cs
@@ -4,9 +4,7 @@ using MixServer.Domain.FileExplorer.Models.Metadata;
 namespace MixServer.Domain.FileExplorer.Models;
 
 public class FileExplorerFileNode(
-    string name,
-    string absolutePath,
-    string extension,
+    NodePath path,
     FileExplorerNodeType type,
     bool exists,
     DateTime creationTimeUtc,
@@ -14,9 +12,7 @@ public class FileExplorerFileNode(
     IFileExplorerFolderNode parent)
     : IFileExplorerFileNode
 {
-    public string Name { get; } = name;
-    public string AbsolutePath { get; } = absolutePath;
-    public string Extension { get; } = extension;
+    public NodePath Path { get; } = path;
     public FileExplorerNodeType Type { get; } = type;
     public bool Exists { get; } = exists;
     public DateTime CreationTimeUtc { get; } = creationTimeUtc;

--- a/src/api/MixServer.Domain/FileExplorer/Models/FileExplorerFileNode.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/FileExplorerFileNode.cs
@@ -1,3 +1,4 @@
+using MixServer.Domain.FileExplorer.Entities;
 using MixServer.Domain.FileExplorer.Enums;
 using MixServer.Domain.FileExplorer.Models.Metadata;
 
@@ -23,4 +24,13 @@ public class FileExplorerFileNode(
                                      Exists && 
                                      Metadata.IsMedia;
     public IFileExplorerFolderNode Parent { get; } = parent;
+}
+
+public class FileExplorerFileNodeWithEntity(
+    IFileExplorerFileNode node,
+    FileExplorerFileNodeEntity entity)
+    : FileExplorerFileNode(node.Path, node.Type, node.Exists, node.CreationTimeUtc, node.Metadata, node.Parent),
+      IFileExplorerFileNodeWithEntity
+{
+    public FileExplorerFileNodeEntity Entity { get; } = entity;
 }

--- a/src/api/MixServer.Domain/FileExplorer/Models/FileExplorerFolder.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/FileExplorerFolder.cs
@@ -20,9 +20,9 @@ public class FileExplorerFolder(IFileExplorerFolderNode node) : IFileExplorerFol
     {
         Func<IFileExplorerNode, object> func = sort.SortMode switch
         {
-            FolderSortMode.Name => i => i.Name,
+            FolderSortMode.Name => i => i.Path.FileName,
             FolderSortMode.Created => i => i.CreationTimeUtc,
-            _ => i => i.Name
+            _ => i => i.Path.FileName
         };
 
         var values = sort.SortMode switch
@@ -40,7 +40,7 @@ public class FileExplorerFolder(IFileExplorerFolderNode node) : IFileExplorerFol
 
     public void AddChild(IFileExplorerNode node)
     {
-        if (!ChildNodes.TryAdd(node.Name, node))
+        if (!ChildNodes.TryAdd(node.Path.FileName, node))
         {
             if (Debugger.IsAttached)
             {

--- a/src/api/MixServer.Domain/FileExplorer/Models/FileExplorerFolderNode.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/FileExplorerFolderNode.cs
@@ -3,8 +3,7 @@ using MixServer.Domain.FileExplorer.Enums;
 namespace MixServer.Domain.FileExplorer.Models;
 
 public class FileExplorerFolderNode(
-    string name,
-    string absolutePath,
+    NodePath path,
     FileExplorerNodeType type,
     bool exists,
     DateTime creationTimeUtc,
@@ -13,8 +12,7 @@ public class FileExplorerFolderNode(
     IFileExplorerFolderNode? parent)
     : IFileExplorerFolderNode
 {
-    public string Name { get; } = name;
-    public string AbsolutePath { get; } = absolutePath;
+    public NodePath Path { get; } = path;
     public FileExplorerNodeType Type { get; } = type;
     public bool Exists { get; } = exists;
     public DateTime CreationTimeUtc { get; } = creationTimeUtc;

--- a/src/api/MixServer.Domain/FileExplorer/Models/FileExplorerFolderNode.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/FileExplorerFolderNode.cs
@@ -1,3 +1,4 @@
+using MixServer.Domain.FileExplorer.Entities;
 using MixServer.Domain.FileExplorer.Enums;
 
 namespace MixServer.Domain.FileExplorer.Models;
@@ -19,4 +20,13 @@ public class FileExplorerFolderNode(
     public bool BelongsToRoot { get; } = belongsToRoot;
     public bool BelongsToRootChild { get; } = belongsToRootChild;
     public IFileExplorerFolderNode? Parent { get; } = parent;
+}
+
+public class FileExplorerFolderNodeWithEntity(
+    IFileExplorerFolderNode node,
+    FileExplorerFolderNodeEntity entity)
+    : FileExplorerFolderNode(node.Path, node.Type, node.Exists, node.CreationTimeUtc, node.BelongsToRoot, node.BelongsToRootChild, node.Parent),
+      IFileExplorerFolderNodeWithEntity
+{
+    public FileExplorerFolderNodeEntity Entity { get; } = entity;
 }

--- a/src/api/MixServer.Domain/FileExplorer/Models/FolderSortRequest.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/FolderSortRequest.cs
@@ -1,0 +1,10 @@
+using MixServer.Domain.FileExplorer.Enums;
+
+namespace MixServer.Domain.FileExplorer.Models;
+
+public class FolderSortRequest : IFolderSortRequest
+{
+    public required NodePath Path { get; init; }
+    public required bool Descending { get; init; }
+    public required FolderSortMode SortMode { get; init; }
+}

--- a/src/api/MixServer.Domain/FileExplorer/Models/IFileExplorerNode.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/IFileExplorerNode.cs
@@ -47,9 +47,8 @@ public interface IFileExplorerFolder
 
 public interface IRootFileExplorerFolder : IFileExplorerFolder
 {
-    bool BelongsToRoot(string? rootPath);
-
-    bool BelongsToRootChild(string rootPath);
-    void RefreshChildren();
     NodePath GetNodePath(string absolutePath);
+    IFileExplorerFolderNode GetRootChildOrThrow(NodePath nodePath);
+    void RefreshChildren();
+    bool DescendantOfRoot(NodePath nodePath);
 }

--- a/src/api/MixServer.Domain/FileExplorer/Models/IFileExplorerNode.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/IFileExplorerNode.cs
@@ -1,3 +1,4 @@
+using MixServer.Domain.FileExplorer.Entities;
 using MixServer.Domain.FileExplorer.Enums;
 using MixServer.Domain.FileExplorer.Models.Metadata;
 
@@ -23,6 +24,11 @@ public interface IFileExplorerFileNode : IFileExplorerNode
     IFileExplorerFolderNode Parent { get; }
 }
 
+public interface IFileExplorerFileNodeWithEntity : IFileExplorerFileNode
+{
+    FileExplorerFileNodeEntity Entity { get; }
+}
+
 public interface IFileExplorerFolderNode : IFileExplorerNode
 {
     bool BelongsToRoot { get; }
@@ -30,6 +36,11 @@ public interface IFileExplorerFolderNode : IFileExplorerNode
     bool BelongsToRootChild { get; }
     
     IFileExplorerFolderNode? Parent { get; }
+}
+
+public interface IFileExplorerFolderNodeWithEntity : IFileExplorerFolderNode
+{
+    FileExplorerFolderNodeEntity Entity { get; }
 }
 
 public interface IFileExplorerFolder

--- a/src/api/MixServer.Domain/FileExplorer/Models/IFileExplorerNode.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/IFileExplorerNode.cs
@@ -5,9 +5,7 @@ namespace MixServer.Domain.FileExplorer.Models;
 
 public interface IFileExplorerNode
 {
-    string Name { get; }
-
-    string AbsolutePath { get; }
+    NodePath Path { get; }
 
     FileExplorerNodeType Type { get; }
 
@@ -18,8 +16,6 @@ public interface IFileExplorerNode
 
 public interface IFileExplorerFileNode : IFileExplorerNode
 {
-    string Extension { get; }
-    
     IFileMetadata Metadata { get; }
 
     bool PlaybackSupported { get; }
@@ -51,8 +47,9 @@ public interface IFileExplorerFolder
 
 public interface IRootFileExplorerFolder : IFileExplorerFolder
 {
-    bool BelongsToRoot(string? absolutePath);
+    bool BelongsToRoot(string? rootPath);
 
-    bool BelongsToRootChild(string? absolutePath);
+    bool BelongsToRootChild(string rootPath);
     void RefreshChildren();
+    NodePath GetNodePath(string absolutePath);
 }

--- a/src/api/MixServer.Domain/FileExplorer/Models/IFolderSortRequest.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/IFolderSortRequest.cs
@@ -2,5 +2,5 @@ namespace MixServer.Domain.FileExplorer.Models;
 
 public interface IFolderSortRequest : IFolderSort
 {
-    public string AbsoluteFolderPath { get; }
+    NodePath Path { get; }
 }

--- a/src/api/MixServer.Domain/FileExplorer/Models/Metadata/MediaInfo.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/Metadata/MediaInfo.cs
@@ -4,7 +4,7 @@ namespace MixServer.Domain.FileExplorer.Models.Metadata;
 
 public class MediaInfo
 {
-    public required NodePath NodePath { get; init; }
+    public required NodePath Path { get; init; }
     
     public required int Bitrate { get; init; }
     

--- a/src/api/MixServer.Domain/FileExplorer/Models/NodePath.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/NodePath.cs
@@ -3,7 +3,7 @@ namespace MixServer.Domain.FileExplorer.Models;
 public record NodePath(string RootPath, string RelativePath)
 {
     public string AbsolutePath => Path.Join(RootPath, RelativePath);
-    public string FileName => Path.GetFileName(RelativePath);
+    public string FileName => Path.GetFileName(AbsolutePath);
     public NodePath Parent => this with { RelativePath = Path.GetDirectoryName(RelativePath) ?? string.Empty };
     
     public string Extension => Path.GetExtension(RelativePath);

--- a/src/api/MixServer.Domain/FileExplorer/Models/NodePath.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Models/NodePath.cs
@@ -1,6 +1,29 @@
-﻿namespace MixServer.Domain.FileExplorer.Models;
+namespace MixServer.Domain.FileExplorer.Models;
 
-public record NodePath(string ParentAbsolutePath, string FileName)
+public record NodePath(string RootPath, string RelativePath)
 {
-    public string AbsolutePath => Path.Join(ParentAbsolutePath, FileName);
+    public string AbsolutePath => Path.Join(RootPath, RelativePath);
+    public string FileName => Path.GetFileName(RelativePath);
+    public NodePath Parent => this with { RelativePath = Path.GetDirectoryName(RelativePath) ?? string.Empty };
+    
+    public string Extension => Path.GetExtension(RelativePath);
+    
+    public bool IsRoot => string.IsNullOrWhiteSpace(RootPath) && string.IsNullOrWhiteSpace(RelativePath);
+    
+    public bool IsRootChild => !string.IsNullOrWhiteSpace(RootPath) && string.IsNullOrWhiteSpace(RelativePath);
+
+    public override string ToString()
+    {
+        return AbsolutePath;
+    }
+
+    public bool IsEqualTo(NodePath? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+        
+        return RootPath == other.RootPath && RelativePath == other.RelativePath;
+    }
 }

--- a/src/api/MixServer.Domain/FileExplorer/Services/Caching/FolderPersistenceService.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Services/Caching/FolderPersistenceService.cs
@@ -1,0 +1,86 @@
+using MixServer.Domain.FileExplorer.Entities;
+using MixServer.Domain.FileExplorer.Models;
+using MixServer.Domain.Sessions.Repositories;
+
+namespace MixServer.Domain.FileExplorer.Services.Caching;
+
+public interface IFolderPersistenceService
+{
+    Task<IFileExplorerFolderNodeWithEntity> GetFolderAsync(NodePath nodePath);
+    Task<IFileExplorerFileNodeWithEntity> GetFileAsync(NodePath nodePath);
+}
+
+public class FolderPersistenceService(
+    IFolderCacheService folderCache,
+    IFolderExplorerNodeEntityRepository nodeRepository,
+    IRootFileExplorerFolder rootFolder) : IFolderPersistenceService
+{
+    public async Task<IFileExplorerFolderNodeWithEntity> GetFolderAsync(NodePath nodePath)
+    {
+        var folder = folderCache.GetOrAdd(nodePath);
+        
+        var nodeEntity = await nodeRepository.GetOrDefaultAsync<FileExplorerFolderNodeEntity>(nodePath);
+        
+        if (nodeEntity is not null)
+        {
+            return new FileExplorerFolderNodeWithEntity(folder.Folder.Node, nodeEntity);
+        }
+        
+        var root = await GetOrAddRootAsync(nodePath);
+        
+        nodeEntity = new FileExplorerFolderNodeEntity
+        {
+            Id = Guid.NewGuid(),
+            RelativePath = folder.Folder.Node.Path.RelativePath,
+            RootChild = root
+        };
+        await nodeRepository.AddAsync(nodeEntity);
+        
+        return new FileExplorerFolderNodeWithEntity(folder.Folder.Node, nodeEntity);
+    }
+
+    public async Task<IFileExplorerFileNodeWithEntity> GetFileAsync(NodePath nodePath)
+    {
+        var file = folderCache.GetFile(nodePath);
+        
+        var nodeEntity = await nodeRepository.GetOrDefaultAsync<FileExplorerFileNodeEntity>(nodePath);
+
+        if (nodeEntity is not null)
+        {
+            return new FileExplorerFileNodeWithEntity(file, nodeEntity);
+        }
+        
+        var root = await GetOrAddRootAsync(nodePath);
+
+        nodeEntity = new FileExplorerFileNodeEntity
+        {
+            Id = Guid.NewGuid(),
+            RelativePath = file.Path.RelativePath,
+            RootChild = root
+        };
+        await nodeRepository.AddAsync(nodeEntity);
+        
+        return new FileExplorerFileNodeWithEntity(file, nodeEntity);
+    }
+
+    private async Task<FileExplorerRootChildNodeEntity> GetOrAddRootAsync(NodePath nodePath)
+    {
+        var rootChild = rootFolder.GetRootChildOrThrow(nodePath);
+
+        var rootEntity = await nodeRepository.GetRootChildOrDefaultAsync(rootChild.Path);
+        
+        if (rootEntity is not null)
+        {
+            return rootEntity;
+        }
+
+        rootEntity = new FileExplorerRootChildNodeEntity
+        {
+            Id = Guid.NewGuid(),
+            RelativePath = rootChild.Path.RootPath
+        };
+        await nodeRepository.AddAsync(rootEntity);
+        
+        return rootEntity;
+    }
+}

--- a/src/api/MixServer.Domain/FileExplorer/Services/Caching/MediaInfoCache.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Services/Caching/MediaInfoCache.cs
@@ -7,39 +7,39 @@ namespace MixServer.Domain.FileExplorer.Services.Caching;
 
 public interface IMediaInfoCache
 {
-    bool TryGet(string absoluteFilePath, [MaybeNullWhen(false)] out MediaInfo mediaInfo);
-    IReadOnlyCollection<NodePath> Remove(IEnumerable<string> absoluteFilePaths);
+    bool TryGet(NodePath path, [MaybeNullWhen(false)] out MediaInfo mediaInfo);
+    IReadOnlyCollection<NodePath> Remove(IEnumerable<NodePath> nodePaths);
     void AddOrReplace(List<MediaInfo> mediaInfo);
 }
 
 public class MediaInfoCache : IMediaInfoCache
 {
-    private ConcurrentDictionary<string, MediaInfo> _cache = new();
+    private ConcurrentDictionary<NodePath, MediaInfo> _cache = new();
     
-    public bool TryGet(string absoluteFilePath, [MaybeNullWhen(false)] out MediaInfo mediaInfo)
+    public bool TryGet(NodePath absoluteFilePath, [MaybeNullWhen(false)] out MediaInfo mediaInfo)
     {
         return _cache.TryGetValue(absoluteFilePath, out mediaInfo);
     }
 
-    public IReadOnlyCollection<NodePath> Remove(IEnumerable<string> absoluteFilePaths)
+    public IReadOnlyCollection<NodePath> Remove(IEnumerable<NodePath> nodePaths)
     {
-        var nodePaths = new List<NodePath>();
-        foreach (var absoluteFilePath in absoluteFilePaths)
+        var outputNodePaths = new List<NodePath>();
+        foreach (var nodePath in nodePaths)
         {
-            if (_cache.TryRemove(absoluteFilePath, out var mediaInfo))
+            if (_cache.TryRemove(nodePath, out var mediaInfo))
             {
-                nodePaths.Add(mediaInfo.NodePath);
+                outputNodePaths.Add(mediaInfo.Path);
             }
         }
         
-        return nodePaths;
+        return outputNodePaths;
     }
 
     public void AddOrReplace(List<MediaInfo> mediaInfo)
     {
         foreach (var info in mediaInfo)
         {
-            _cache[info.NodePath.AbsolutePath] = info;
+            _cache[info.Path] = info;
         }
     }
 }

--- a/src/api/MixServer.Domain/FileExplorer/Services/FileNotificationService.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Services/FileNotificationService.cs
@@ -53,17 +53,17 @@ public class FileNotificationService(
         
         var expectedIndexes = await GetExpectedIndexesAsync(sp, parent, e.Item);
         
-        await callbackService.FileExplorerNodeUpdated(expectedIndexes, e.Item, e.OldFullName);
+        await callbackService.FileExplorerNodeUpdated(expectedIndexes, e.Item, e.OldPath);
     }
 
     private async Task FolderCacheServiceOnItemRemoved(object? sender, IServiceProvider sp, FolderCacheServiceItemRemovedEventArgs e)
     {
-        await callbackService.FileExplorerNodeDeleted(e.Parent, e.FullName);
+        await callbackService.FileExplorerNodeDeleted(e.Parent, e.Path);
     }
     
     private async Task TranscodeCacheOnTranscodeStatusUpdated(object? sender, IServiceProvider sp, TranscodeStatusUpdatedEventArgs e)
     {
-        var (parent, file) = folderCacheService.GetFileAndFolder(e.AbsoluteFilePath);
+        var (parent, file) = folderCacheService.GetFileAndFolder(e.Path);
         
         var expectedIndexes = await GetExpectedIndexesAsync(sp, parent, file);
         
@@ -87,13 +87,13 @@ public class FileNotificationService(
     private async Task<Dictionary<string, int>> GetExpectedIndexesAsync(IServiceProvider sp, IFileExplorerFolder parent, IFileExplorerNode node)
     {
         var sorts = await sp.GetRequiredService<IFolderSortRepository>()
-            .GetFolderSortsAsync(callbackService.ConnectedUserIds, parent.Node.AbsolutePath);
+            .GetFolderSortsAsync(callbackService.ConnectedUserIds, parent.Node.Path.AbsolutePath);
 
         var expectedIndexes = new Dictionary<string, int>();
         foreach (var (userId, sort) in sorts)
         {
             var list = parent.GenerateSortedChildren<IFileExplorerNode>(sort).ToList();
-            var index = list.FindIndex(f => f.AbsolutePath == node.AbsolutePath);
+            var index = list.FindIndex(f => f.Path.RootPath == node.Path.RootPath && f.Path.RelativePath == node.Path.RelativePath);
             expectedIndexes[userId] = index;
         }
         

--- a/src/api/MixServer.Domain/FileExplorer/Services/FileNotificationService.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Services/FileNotificationService.cs
@@ -87,7 +87,7 @@ public class FileNotificationService(
     private async Task<Dictionary<string, int>> GetExpectedIndexesAsync(IServiceProvider sp, IFileExplorerFolder parent, IFileExplorerNode node)
     {
         var sorts = await sp.GetRequiredService<IFolderSortRepository>()
-            .GetFolderSortsAsync(callbackService.ConnectedUserIds, parent.Node.Path.AbsolutePath);
+            .GetFolderSortsAsync(callbackService.ConnectedUserIds, parent.Node.Path);
 
         var expectedIndexes = new Dictionary<string, int>();
         foreach (var (userId, sort) in sorts)

--- a/src/api/MixServer.Domain/FileExplorer/Services/IFileService.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Services/IFileService.cs
@@ -4,17 +4,15 @@ namespace MixServer.Domain.FileExplorer.Services;
 
 public interface IFileService
 {
-    Task<IFileExplorerFolder> GetFolderAsync(string absolutePath);
-    Task<IFileExplorerFolder> GetFolderOrRootAsync(string? absolutePath);
-    List<IFileExplorerFileNode> GetFiles(IReadOnlyList<string> absoluteFilePaths);
-    IFileExplorerFileNode GetFile(string absoluteFolderPath, string fileName);
-    IFileExplorerFileNode GetFile(string absoluteFilePath);
+    Task<IFileExplorerFolder> GetFolderAsync(NodePath nodePath);
+    Task<IFileExplorerFolder> GetFolderOrRootAsync(NodePath? nodePath);
+    List<IFileExplorerFileNode> GetFiles(IReadOnlyList<NodePath> nodePaths);
+    IFileExplorerFileNode GetFile(NodePath nodePath);
     void CopyNode(
-        string sourcePath,
-        string destinationFolder,
-        string destinationName,
+        NodePath sourcePath,
+        NodePath destinationPath,
         bool move,
         bool overwrite);
-    void DeleteNode(string absolutePath);
+    void DeleteNode(NodePath nodePath);
     Task SetFolderSortAsync(IFolderSortRequest request);
 }

--- a/src/api/MixServer.Domain/FileExplorer/Services/IMimeTypeService.cs
+++ b/src/api/MixServer.Domain/FileExplorer/Services/IMimeTypeService.cs
@@ -1,6 +1,8 @@
+using MixServer.Domain.FileExplorer.Models;
+
 namespace MixServer.Domain.FileExplorer.Services;
 
 public interface IMimeTypeService
 {
-    string GetMimeType(string absolutePath, string extension);
+    string GetMimeType(NodePath path);
 }

--- a/src/api/MixServer.Domain/Queueing/Services/IQueueService.cs
+++ b/src/api/MixServer.Domain/Queueing/Services/IQueueService.cs
@@ -17,5 +17,5 @@ public interface IQueueService
     void ClearQueue();
     Task<QueueSnapshot> GenerateQueueSnapshotAsync();
     Task<IFileExplorerFileNode> GetCurrentPositionFileOrThrowAsync();
-    string? GetCurrentQueueFolderAbsolutePath();
+    NodePath? GetCurrentQueueFolderPath();
 }

--- a/src/api/MixServer.Domain/Sessions/Models/PlaybackState.cs
+++ b/src/api/MixServer.Domain/Sessions/Models/PlaybackState.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using MixServer.Domain.Exceptions;
+using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.FileExplorer.Models.Metadata;
 using MixServer.Domain.Sessions.Entities;
 using MixServer.Domain.Sessions.Enums;
@@ -10,7 +11,6 @@ public interface IPlaybackState
 {
     string UserId { get; }
     Guid? SessionId { get; }
-    string AbsolutePath { get; }
     Guid? LastPlaybackDeviceId { get; }
     Guid? DeviceId { get; }
     bool Playing { get; }
@@ -28,7 +28,7 @@ public class PlaybackState(IPlaybackState session, ILogger<PlaybackState> logger
 
     public Guid? SessionId { get; private set; } = session.SessionId;
 
-    public string AbsolutePath { get; private set; } = session.AbsolutePath;
+    public required NodePath? NodePath { get; set; }
 
     public Guid? LastPlaybackDeviceId { get; private set; } = session.LastPlaybackDeviceId;
 
@@ -56,7 +56,7 @@ public class PlaybackState(IPlaybackState session, ILogger<PlaybackState> logger
 
     public TimeSpan CurrentTime { get; private set; } = session.CurrentTime;
 
-    public void UpdateWithoutEvents(IPlaybackSession session, bool includePlaying)
+    public void UpdateWithoutEvents(IPlaybackSession session, NodePath nodePath, bool includePlaying)
     {
         if (session.UserId != UserId)
         {
@@ -66,7 +66,7 @@ public class PlaybackState(IPlaybackState session, ILogger<PlaybackState> logger
         
         SessionId = session.SessionId;
         DeviceId = session.DeviceId;
-        AbsolutePath = session.AbsolutePath;
+        NodePath = nodePath;
 
         if (includePlaying)
         {
@@ -162,7 +162,7 @@ public class PlaybackState(IPlaybackState session, ILogger<PlaybackState> logger
     public void ClearSession()
     {
         SessionId = null;
-        AbsolutePath = string.Empty;
+        NodePath = null;
         CurrentTime = TimeSpan.Zero;
     }
 }

--- a/src/api/MixServer.Domain/Sessions/Repositories/IFolderExplorerNodeEntityRepository.cs
+++ b/src/api/MixServer.Domain/Sessions/Repositories/IFolderExplorerNodeEntityRepository.cs
@@ -1,0 +1,14 @@
+using MixServer.Domain.FileExplorer.Entities;
+using MixServer.Domain.FileExplorer.Models;
+using MixServer.Domain.Persistence;
+
+namespace MixServer.Domain.Sessions.Repositories;
+
+public interface IFolderExplorerNodeEntityRepository : ITransientRepository
+{
+    Task<TEntity?> GetOrDefaultAsync<TEntity>(NodePath nodePath)
+        where TEntity : FileExplorerNodeEntity;
+
+    Task<FileExplorerRootChildNodeEntity?> GetRootChildOrDefaultAsync(NodePath rootChild);
+    Task AddAsync(FileExplorerNodeEntityBase nodeEntity);
+}

--- a/src/api/MixServer.Domain/Sessions/Repositories/IFolderSortRepository.cs
+++ b/src/api/MixServer.Domain/Sessions/Repositories/IFolderSortRepository.cs
@@ -8,5 +8,5 @@ public interface IFolderSortRepository : ITransientRepository
 {
     Task AddAsync(FolderSort folderSort);
 
-    Task<Dictionary<string, IFolderSort>> GetFolderSortsAsync(IReadOnlyCollection<string> usernames, string absoluteFolderPath);
+    Task<Dictionary<string, IFolderSort>> GetFolderSortsAsync(IReadOnlyCollection<string> usernames, NodePath nodePath);
 }

--- a/src/api/MixServer.Domain/Sessions/Requests/UpdateSessionRequest.cs
+++ b/src/api/MixServer.Domain/Sessions/Requests/UpdateSessionRequest.cs
@@ -1,15 +1,13 @@
-﻿namespace MixServer.Domain.Sessions.Requests;
+﻿using MixServer.Domain.FileExplorer.Models;
+
+namespace MixServer.Domain.Sessions.Requests;
 
 public interface IAddOrUpdateSessionRequest
 {
-    string AbsoluteFilePath { get; }
+    NodePath NodePath { get; }
 }
 
 public class AddOrUpdateSessionRequest : IAddOrUpdateSessionRequest
 {
-    public string? ParentAbsoluteFilePath { get; set; }
-
-    public string FileName { get; set; } = string.Empty;
-
-    public string AbsoluteFilePath => Path.Join(ParentAbsoluteFilePath, FileName);
+    public required NodePath NodePath { get; set; }
 }

--- a/src/api/MixServer.Domain/Sessions/Services/ISessionService.cs
+++ b/src/api/MixServer.Domain/Sessions/Services/ISessionService.cs
@@ -8,7 +8,6 @@ public interface ISessionService
     Task LoadPlaybackStateAsync();
     Task<PlaybackSession> AddOrUpdateSessionAsync(IAddOrUpdateSessionRequest request);
     void ClearUsersCurrentSession();
-    Task<PlaybackSession> GetPlaybackSessionByIdAsync(Guid id, string username);
     Task<PlaybackSession> GetPlaybackSessionByIdAsync(Guid id);
     Task<PlaybackSession> GetCurrentPlaybackSessionWithFileAsync();
     Task<PlaybackSession> GetCurrentPlaybackSessionAsync();

--- a/src/api/MixServer.Domain/Sessions/Services/SessionHydrationService.cs
+++ b/src/api/MixServer.Domain/Sessions/Services/SessionHydrationService.cs
@@ -1,4 +1,3 @@
-using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.FileExplorer.Services;
 using MixServer.Domain.Sessions.Entities;
 using MixServer.Domain.Users.Services;
@@ -13,14 +12,11 @@ public interface ISessionHydrationService
 public class SessionHydrationService(
     IFileService fileService,
     IPlaybackTrackingService playbackTrackingService,
-    IStreamKeyService streamKeyService,
-    IRootFileExplorerFolder rootFolder) : ISessionHydrationService
+    IStreamKeyService streamKeyService) : ISessionHydrationService
 {
     public void Hydrate(IPlaybackSession session)
     {
-        var nodePath = rootFolder.GetNodePath(session.AbsolutePath);
-        
-        var currentNode = fileService.GetFile(nodePath);
+        var currentNode = fileService.GetFile(session.NodeEntity.Path);
 
         playbackTrackingService.Populate(session);
         

--- a/src/api/MixServer.Domain/Sessions/Services/SessionHydrationService.cs
+++ b/src/api/MixServer.Domain/Sessions/Services/SessionHydrationService.cs
@@ -1,3 +1,4 @@
+using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.FileExplorer.Services;
 using MixServer.Domain.Sessions.Entities;
 using MixServer.Domain.Users.Services;
@@ -12,11 +13,14 @@ public interface ISessionHydrationService
 public class SessionHydrationService(
     IFileService fileService,
     IPlaybackTrackingService playbackTrackingService,
-    IStreamKeyService streamKeyService) : ISessionHydrationService
+    IStreamKeyService streamKeyService,
+    IRootFileExplorerFolder rootFolder) : ISessionHydrationService
 {
     public void Hydrate(IPlaybackSession session)
     {
-        var currentNode = fileService.GetFile(session.AbsolutePath);
+        var nodePath = rootFolder.GetNodePath(session.AbsolutePath);
+        
+        var currentNode = fileService.GetFile(nodePath);
 
         playbackTrackingService.Populate(session);
         

--- a/src/api/MixServer.Domain/Sessions/Validators/CanPlayOnDeviceValidator.cs
+++ b/src/api/MixServer.Domain/Sessions/Validators/CanPlayOnDeviceValidator.cs
@@ -19,9 +19,9 @@ public class CanPlayOnDeviceValidator(ITranscodeCache transcodeCache,
 {
     public void ValidateCanPlayOrThrow(IDeviceState deviceState, IFileExplorerFileNode file)
     {
-        if (!deviceState.CanPlay(file) && transcodeCache.GetTranscodeStatus(file.AbsolutePath) != TranscodeState.Completed)
+        if (!deviceState.CanPlay(file) && transcodeCache.GetTranscodeStatus(file.Path) != TranscodeState.Completed)
         {
-            throw new InvalidRequestException(nameof(file), $"{file.AbsolutePath} is not supported for playback on this device");
+            throw new InvalidRequestException(nameof(file), $"{file.Path.AbsolutePath} is not supported for playback on this device");
         }
     }
 
@@ -34,6 +34,6 @@ public class CanPlayOnDeviceValidator(ITranscodeCache transcodeCache,
     {
         return file.PlaybackSupported && 
                (deviceState.CanPlay(file) ||
-                transcodeCache.GetTranscodeStatus(file.AbsolutePath) == TranscodeState.Completed);
+                transcodeCache.GetTranscodeStatus(file.Path) == TranscodeState.Completed);
     }
 }

--- a/src/api/MixServer.Domain/Settings/CacheFolderSettings.cs
+++ b/src/api/MixServer.Domain/Settings/CacheFolderSettings.cs
@@ -6,5 +6,5 @@ public class CacheFolderSettings
     
     public string DirectoryAbsolutePath => Path.GetFullPath(Directory);
     
-    public string TranscodesFolder => Path.Join(Directory, "transcodes");
+    public string TranscodesFolder => Path.Join(DirectoryAbsolutePath, "transcodes");
 }

--- a/src/api/MixServer.Domain/Settings/CacheFolderSettings.cs
+++ b/src/api/MixServer.Domain/Settings/CacheFolderSettings.cs
@@ -4,5 +4,7 @@ public class CacheFolderSettings
 {
     public string Directory { get; set; } = "./data";
     
+    public string DirectoryAbsolutePath => Path.GetFullPath(Directory);
+    
     public string TranscodesFolder => Path.Join(Directory, "transcodes");
 }

--- a/src/api/MixServer.Domain/Streams/Caches/TranscodeCache.cs
+++ b/src/api/MixServer.Domain/Streams/Caches/TranscodeCache.cs
@@ -165,7 +165,7 @@ public class TranscodeCache(
             folder.ItemUpdated += TranscodeFolderOnItemUpdated;
             folder.ItemRemoved += TranscodeFolderOnItemRemoved;
 
-            var nodePath = rootFolder.GetNodePath(transcodeEntity.AbsolutePath);
+            var nodePath = transcodeEntity.NodeEntity.Path;
             
             var transcode = new TranscodeCacheItem(loggerFactory.CreateLogger<TranscodeCacheItem>())
             {

--- a/src/api/MixServer.Domain/Streams/Entities/Transcode.cs
+++ b/src/api/MixServer.Domain/Streams/Entities/Transcode.cs
@@ -1,8 +1,31 @@
-﻿namespace MixServer.Domain.Streams.Entities;
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using MixServer.Domain.FileExplorer.Entities;
+
+namespace MixServer.Domain.Streams.Entities;
 
 public class Transcode
 {
-    public Guid Id { get; set; }
+    public required Guid Id { get; set; }
     
+    // TODO: Make this non-nullable after migration to new root, relative paths is complete.
+    public FileExplorerFileNodeEntity? Node { get; set; }
+    public Guid? NodeId { get; set; }
+    
+    [Obsolete("Use Node instead.")]
     public string AbsolutePath { get; set; } = string.Empty;
+    
+    // Workaround for application code to pretend Node is not nullable
+    [NotMapped]
+    public required FileExplorerFileNodeEntity NodeEntity
+    {
+        get => Node ?? throw new InvalidOperationException("Node is not set.");
+        set => Node = value;
+    }
+    
+    [NotMapped]
+    public required Guid NodeIdEntity
+    {
+        get => NodeId ?? throw new InvalidOperationException("NodeId is not set.");
+        set => NodeId = value;
+    }
 }

--- a/src/api/MixServer.Domain/Streams/Events/TranscodeStatusUpdatedEventArgs.cs
+++ b/src/api/MixServer.Domain/Streams/Events/TranscodeStatusUpdatedEventArgs.cs
@@ -1,6 +1,8 @@
-﻿namespace MixServer.Domain.Streams.Events;
+﻿using MixServer.Domain.FileExplorer.Models;
+
+namespace MixServer.Domain.Streams.Events;
 
 public class TranscodeStatusUpdatedEventArgs : EventArgs
 {
-    public required string AbsoluteFilePath { get; init; }
+    public required NodePath Path { get; init; }
 }

--- a/src/api/MixServer.Domain/Streams/Models/StreamFile.cs
+++ b/src/api/MixServer.Domain/Streams/Models/StreamFile.cs
@@ -1,10 +1,12 @@
-﻿namespace MixServer.Domain.Streams.Models;
+﻿using MixServer.Domain.FileExplorer.Models;
+
+namespace MixServer.Domain.Streams.Models;
 
 public abstract class StreamFile
 {
     public abstract string ContentType { get; }
     
-    public required string FilePath { get; init; }
+    public required NodePath FilePath { get; init; }
 }
 
 public class DirectStreamFile(string contentType) : StreamFile

--- a/src/api/MixServer.Domain/Streams/Models/TranscodeCacheItem.cs
+++ b/src/api/MixServer.Domain/Streams/Models/TranscodeCacheItem.cs
@@ -16,7 +16,7 @@ public class TranscodeCacheItem(ILogger<TranscodeCacheItem> logger)
 
     public required Guid TranscodeId { get; init; }
     
-    public required string AbsoluteFilePath { get; init; }
+    public required NodePath Path { get; init; }
 
     public bool HasCompletePlaylist
     {
@@ -64,7 +64,7 @@ public class TranscodeCacheItem(ILogger<TranscodeCacheItem> logger)
             return false;
         }
 
-        var lines = await File.ReadAllLinesAsync(playlistFile.AbsolutePath);
+        var lines = await File.ReadAllLinesAsync(playlistFile.Path.AbsolutePath);
         
         return lines.LastOrDefault()?.StartsWith("#EXT-X-ENDLIST") ?? false;
     }
@@ -78,19 +78,19 @@ public class TranscodeCacheItem(ILogger<TranscodeCacheItem> logger)
 
         return new HlsPlaylistStreamFile
         {
-            FilePath = playlistFile.AbsolutePath
+            FilePath = playlistFile.Path
         };
     }
     
     private bool TryGetPlaylistFile([MaybeNullWhen(false)] out IFileExplorerNode playlistFile)
     {
-        playlistFile = TranscodeFolder.Folder.Children.SingleOrDefault(s => s.Name.EndsWith(".m3u8"));
+        playlistFile = TranscodeFolder.Folder.Children.SingleOrDefault(s => s.Path.Extension == ".m3u8");
         return playlistFile is not null && playlistFile.Exists;
     }
 
     public HlsSegmentStreamFile GetSegmentOrThrow(string segment)
     {
-        var segmentFile = TranscodeFolder.Folder.Children.SingleOrDefault(s => s.Name == segment);
+        var segmentFile = TranscodeFolder.Folder.Children.SingleOrDefault(s => s.Path.FileName == segment);
         
         if (segmentFile is null || !segmentFile.Exists)
         {
@@ -99,7 +99,7 @@ public class TranscodeCacheItem(ILogger<TranscodeCacheItem> logger)
         
         return new HlsSegmentStreamFile
         {
-            FilePath = segmentFile.AbsolutePath
+            FilePath = segmentFile.Path
         };
     }
 }

--- a/src/api/MixServer.Domain/Streams/Repositories/ITranscodeRepository.cs
+++ b/src/api/MixServer.Domain/Streams/Repositories/ITranscodeRepository.cs
@@ -10,4 +10,5 @@ public interface ITranscodeRepository : ITransientRepository
     Task<Transcode> GetAsync(NodePath path);
     Task<Transcode?> GetOrDefaultAsync(NodePath path);
     Task<Transcode> GetOrAddAsync(NodePath path);
+    void Remove(Guid transcodeId);
 }

--- a/src/api/MixServer.Domain/Streams/Repositories/ITranscodeRepository.cs
+++ b/src/api/MixServer.Domain/Streams/Repositories/ITranscodeRepository.cs
@@ -1,4 +1,5 @@
-﻿using MixServer.Domain.Persistence;
+﻿using MixServer.Domain.FileExplorer.Models;
+using MixServer.Domain.Persistence;
 using MixServer.Domain.Streams.Entities;
 
 namespace MixServer.Domain.Streams.Repositories;
@@ -6,7 +7,7 @@ namespace MixServer.Domain.Streams.Repositories;
 public interface ITranscodeRepository : ITransientRepository
 {
     Task<Transcode> GetAsync(Guid id);
-    Task<Transcode> GetAsync(string fileAbsolutePath);
-    Task<Transcode?> GetOrDefaultAsync(string fileAbsolutePath);
-    Task<Transcode> GetOrAddAsync(string fileAbsolutePath);
+    Task<Transcode> GetAsync(NodePath path);
+    Task<Transcode?> GetOrDefaultAsync(NodePath path);
+    Task<Transcode> GetOrAddAsync(NodePath path);
 }

--- a/src/api/MixServer.Domain/Streams/Repositories/ITranscodeRepository.cs
+++ b/src/api/MixServer.Domain/Streams/Repositories/ITranscodeRepository.cs
@@ -7,8 +7,7 @@ namespace MixServer.Domain.Streams.Repositories;
 public interface ITranscodeRepository : ITransientRepository
 {
     Task<Transcode> GetAsync(Guid id);
-    Task<Transcode> GetAsync(NodePath path);
     Task<Transcode?> GetOrDefaultAsync(NodePath path);
-    Task<Transcode> GetOrAddAsync(NodePath path);
+    Task AddAsync(Transcode transcode);
     void Remove(Guid transcodeId);
 }

--- a/src/api/MixServer.Domain/Streams/Services/TranscodeService.cs
+++ b/src/api/MixServer.Domain/Streams/Services/TranscodeService.cs
@@ -1,6 +1,7 @@
 using CliWrap;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.FileExplorer.Models.Metadata;
 using MixServer.Domain.Persistence;
 using MixServer.Domain.Settings;
@@ -13,7 +14,7 @@ namespace MixServer.Domain.Streams.Services;
 
 public interface ITranscodeService
 {
-    Task RequestTranscodeAsync(string absoluteFilePath, int bitrate);
+    Task RequestTranscodeAsync(NodePath path, int bitrate);
 }
 
 public class TranscodeService(
@@ -27,16 +28,16 @@ public class TranscodeService(
     private const int HlsTime = 4;
     private const int DefaultBitrate = 192;
     
-    public async Task RequestTranscodeAsync(string absoluteFilePath, int bitrate)
+    public async Task RequestTranscodeAsync(NodePath path, int bitrate)
     {
-        var transcode = await transcodeRepository.GetOrAddAsync(absoluteFilePath);
+        var transcode = await transcodeRepository.GetOrAddAsync(path);
 
         await unitOfWork.SaveChangesAsync();
         
         var transcodeIdString = transcode.Id.ToString();
         
         Directory.CreateDirectory(GetTranscodeFolder(transcode.Id.ToString()));
-        logger.LogDebug("Transcode requested for {AbsoluteFilePath} ({Hash})", absoluteFilePath, transcodeIdString);
+        logger.LogDebug("Transcode requested for {AbsoluteFilePath} ({Hash})", path.AbsolutePath, transcodeIdString);
         
         _ = Task.Run(() => ProcessTranscode(transcode, bitrate));
     }

--- a/src/api/MixServer.Infrastructure/EF/Configuration/FileExplorerNodeEntityBaseEntityConfiguration.cs
+++ b/src/api/MixServer.Infrastructure/EF/Configuration/FileExplorerNodeEntityBaseEntityConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MixServer.Domain.FileExplorer.Entities;
+using MixServer.Domain.FileExplorer.Enums;
+
+namespace MixServer.Infrastructure.EF.Configuration;
+
+public class FileExplorerNodeEntityBaseEntityConfiguration : IEntityTypeConfiguration<FileExplorerNodeEntityBase>
+{
+    public void Configure(EntityTypeBuilder<FileExplorerNodeEntityBase> builder)
+    {
+        builder.HasKey(k => k.Id);
+        
+        builder.UseTphMappingStrategy()
+            .HasDiscriminator(e => e.NodeType)
+            .HasValue<FileExplorerNodeEntityBase>(FileExplorerEntityNodeType.Base)
+            .HasValue<FileExplorerRootChildNodeEntity>(FileExplorerEntityNodeType.RootChild)
+            .HasValue<FileExplorerNodeEntity>(FileExplorerEntityNodeType.Node)
+            .HasValue<FileExplorerFolderNodeEntity>(FileExplorerEntityNodeType.Folder)
+            .HasValue<FileExplorerFileNodeEntity>(FileExplorerEntityNodeType.File);
+    }
+}

--- a/src/api/MixServer.Infrastructure/EF/Configuration/FileExplorerNodeEntityTypeConfiguration.cs
+++ b/src/api/MixServer.Infrastructure/EF/Configuration/FileExplorerNodeEntityTypeConfiguration.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MixServer.Domain.FileExplorer.Entities;
+
+namespace MixServer.Infrastructure.EF.Configuration;
+
+public class FileExplorerNodeEntityTypeConfiguration : IEntityTypeConfiguration<FileExplorerNodeEntity>
+{
+    public void Configure(EntityTypeBuilder<FileExplorerNodeEntity> builder)
+    {
+        builder
+            .HasIndex(i => new { i.RootChildId, i.RelativePath })
+            .IsUnique();
+        
+        builder.HasOne(o => o.RootChild)
+            .WithMany()
+            .HasForeignKey(f => f.RootChildId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/api/MixServer.Infrastructure/EF/Configuration/FolderSortEntityTypeConfiguration.cs
+++ b/src/api/MixServer.Infrastructure/EF/Configuration/FolderSortEntityTypeConfiguration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MixServer.Domain.FileExplorer.Entities;
+
+namespace MixServer.Infrastructure.EF.Configuration;
+
+public class FolderSortEntityTypeConfiguration : IEntityTypeConfiguration<FolderSort>
+{
+    public void Configure(EntityTypeBuilder<FolderSort> builder)
+    {
+        builder.HasOne(o => o.Node)
+            .WithMany()
+            .HasForeignKey(o => o.NodeId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/api/MixServer.Infrastructure/EF/Configuration/PlaybackSessionEntityTypeConfiguration.cs
+++ b/src/api/MixServer.Infrastructure/EF/Configuration/PlaybackSessionEntityTypeConfiguration.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MixServer.Domain.Sessions.Entities;
+
+namespace MixServer.Infrastructure.EF.Configuration;
+
+public class PlaybackSessionEntityTypeConfiguration : IEntityTypeConfiguration<PlaybackSession>
+{
+    public void Configure(EntityTypeBuilder<PlaybackSession> builder)
+    {
+        builder
+            .HasOne(o => o.Node)
+            .WithMany()
+            .HasForeignKey(o => o.NodeId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/api/MixServer.Infrastructure/EF/Configuration/TranscodeTypeConfiguration.cs
+++ b/src/api/MixServer.Infrastructure/EF/Configuration/TranscodeTypeConfiguration.cs
@@ -10,6 +10,9 @@ public class TranscodeTypeConfiguration : IEntityTypeConfiguration<Transcode>
     {
         builder.HasKey(k => k.Id);
         
-        builder.HasIndex(i => i.AbsolutePath).IsUnique();
+        builder.HasOne(o => o.Node)
+            .WithOne(f => f.Transcode)
+            .HasForeignKey<Transcode>(o => o.NodeId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/src/api/MixServer.Infrastructure/EF/Entities/DbUser.cs
+++ b/src/api/MixServer.Infrastructure/EF/Entities/DbUser.cs
@@ -28,7 +28,7 @@ public class DbUser : IdentityUser, IUser
 
     public IFolderSort GetSortOrDefault(NodePath nodePath)
     {
-        var sort = FolderSorts.SingleOrDefault(s => s.AbsoluteFolderPath == nodePath.AbsolutePath);
+        var sort = FolderSorts.SingleOrDefault(s => s.NodeEntity.Path.IsEqualTo(nodePath));
 
         if (sort == null)
         {

--- a/src/api/MixServer.Infrastructure/EF/Entities/DbUser.cs
+++ b/src/api/MixServer.Infrastructure/EF/Entities/DbUser.cs
@@ -26,9 +26,9 @@ public class DbUser : IdentityUser, IUser
     [NotMapped]
     public IList<Role> Roles { get; set; } = new List<Role>();
 
-    public IFolderSort GetSortOrDefault(string absoluteFolderPath)
+    public IFolderSort GetSortOrDefault(NodePath nodePath)
     {
-        var sort = FolderSorts.SingleOrDefault(s => s.AbsoluteFolderPath == absoluteFolderPath);
+        var sort = FolderSorts.SingleOrDefault(s => s.AbsoluteFolderPath == nodePath.AbsolutePath);
 
         if (sort == null)
         {

--- a/src/api/MixServer.Infrastructure/EF/Extensions/EfIncludeExtensions.cs
+++ b/src/api/MixServer.Infrastructure/EF/Extensions/EfIncludeExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using MixServer.Domain.FileExplorer.Entities;
+using MixServer.Domain.Sessions.Entities;
+using MixServer.Domain.Streams.Entities;
+
+namespace MixServer.Infrastructure.EF.Extensions;
+
+public static class EfIncludeExtensions
+{
+    public static IQueryable<PlaybackSession> IncludeNode(this IQueryable<PlaybackSession> query)
+    {
+        return query.Include(session => session.Node)
+            .ThenInclude(t => t!.RootChild)
+            .Include(i => i.Node)
+            .ThenInclude(t => t!.Transcode);
+    }
+    
+    public static IQueryable<FolderSort> IncludeNode(this IQueryable<FolderSort> query)
+    {
+        return query.Include(session => session.Node)
+            .ThenInclude(t => t!.RootChild);
+    }
+    
+    public static IQueryable<Transcode> IncludeNode(this IQueryable<Transcode> query)
+    {
+        return query
+            .Include(session => session.Node)
+            .ThenInclude(t => t!.RootChild);
+    }
+}

--- a/src/api/MixServer.Infrastructure/EF/MixServerDbContext.cs
+++ b/src/api/MixServer.Infrastructure/EF/MixServerDbContext.cs
@@ -22,6 +22,8 @@ public class MixServerDbContext(DbContextOptions<MixServerDbContext> options) : 
 
     public DbSet<UserCredential> UserCredentials { get; set; }
     
+    public DbSet<FileExplorerNodeEntityBase> Nodes { get; set; }
+    
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/src/api/MixServer.Infrastructure/EF/Repositories/EfFolderExplorerNodeEntityRepository.cs
+++ b/src/api/MixServer.Infrastructure/EF/Repositories/EfFolderExplorerNodeEntityRepository.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using MixServer.Domain.FileExplorer.Entities;
+using MixServer.Domain.FileExplorer.Models;
+using MixServer.Domain.Sessions.Repositories;
+
+namespace MixServer.Infrastructure.EF.Repositories;
+
+public class EfFolderExplorerNodeEntityRepository(MixServerDbContext context) : IFolderExplorerNodeEntityRepository
+{
+    public async Task<TEntity?> GetOrDefaultAsync<TEntity>(NodePath nodePath) where TEntity : FileExplorerNodeEntity
+    {
+        IQueryable<TEntity> query = context.Nodes
+            .OfType<TEntity>()
+            .Include(i => i.RootChild);
+        
+        if (typeof(TEntity).IsAssignableTo(typeof(FileExplorerFileNodeEntity)))
+        {
+            query = query
+                .Cast<FileExplorerFileNodeEntity>()
+                .Include(i => i.Transcode)
+                .Cast<TEntity>();
+        }
+        
+        return await query
+            .FirstOrDefaultAsync(f => f.RelativePath == nodePath.RelativePath && f.RootChild.RelativePath == nodePath.RootPath);
+    }
+
+    public async Task<FileExplorerRootChildNodeEntity?> GetRootChildOrDefaultAsync(NodePath rootChild)
+    {
+        return await context.Nodes
+            .OfType<FileExplorerRootChildNodeEntity>()
+            .FirstOrDefaultAsync(f => f.RelativePath == rootChild.RootPath);
+    }
+
+    public async Task AddAsync(FileExplorerNodeEntityBase nodeEntity)
+    {
+        await context.Nodes.AddAsync(nodeEntity);
+    }
+}

--- a/src/api/MixServer.Infrastructure/EF/Repositories/EfPlaybackSessionRepository.cs
+++ b/src/api/MixServer.Infrastructure/EF/Repositories/EfPlaybackSessionRepository.cs
@@ -2,6 +2,7 @@
 using MixServer.Domain.Exceptions;
 using MixServer.Domain.Sessions.Entities;
 using MixServer.Domain.Sessions.Repositories;
+using MixServer.Infrastructure.EF.Extensions;
 
 namespace MixServer.Infrastructure.EF.Repositories;
 
@@ -10,6 +11,7 @@ public class EfPlaybackSessionRepository(MixServerDbContext context) : IPlayback
     public async Task<PlaybackSession> GetAsync(Guid id)
     {
         return await context.PlaybackSessions
+                   .IncludeNode()
                    .SingleOrDefaultAsync(s => s.Id == id)
                ?? throw new NotFoundException(nameof(context.PlaybackSessions), id);
     }

--- a/src/api/MixServer.Infrastructure/EF/Repositories/EfTranscodeRepository.cs
+++ b/src/api/MixServer.Infrastructure/EF/Repositories/EfTranscodeRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using MixServer.Domain.Exceptions;
+using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.Streams.Entities;
 using MixServer.Domain.Streams.Repositories;
 
@@ -13,19 +14,19 @@ public class EfTranscodeRepository(MixServerDbContext context) : ITranscodeRepos
                ?? throw new NotFoundException(nameof(Transcode), id);
     }
 
-    public async Task<Transcode> GetAsync(string fileAbsolutePath)
+    public async Task<Transcode> GetAsync(NodePath nodePath)
     {
-        return await GetOrDefaultAsync(fileAbsolutePath) ?? throw new NotFoundException(nameof(Transcode), fileAbsolutePath);
+        return await GetOrDefaultAsync(nodePath) ?? throw new NotFoundException(nameof(Transcode), nodePath.AbsolutePath);
     }
 
-    public Task<Transcode?> GetOrDefaultAsync(string fileAbsolutePath)
+    public Task<Transcode?> GetOrDefaultAsync(NodePath nodePath)
     {
-        return context.Transcodes.SingleOrDefaultAsync(s => s.AbsolutePath == fileAbsolutePath);
+        return context.Transcodes.SingleOrDefaultAsync(s => s.AbsolutePath == nodePath.AbsolutePath);
     }
 
-    public async Task<Transcode> GetOrAddAsync(string fileAbsolutePath)
+    public async Task<Transcode> GetOrAddAsync(NodePath nodePath)
     {
-        var existing = await GetOrDefaultAsync(fileAbsolutePath);
+        var existing = await GetOrDefaultAsync(nodePath);
         
         if (existing is not null)
         {
@@ -35,7 +36,7 @@ public class EfTranscodeRepository(MixServerDbContext context) : ITranscodeRepos
         var transcode = new Transcode
         {
             Id = Guid.NewGuid(),
-            AbsolutePath = fileAbsolutePath,
+            AbsolutePath = nodePath.AbsolutePath,
         };
         await context.Transcodes.AddAsync(transcode);
         

--- a/src/api/MixServer.Infrastructure/EF/Repositories/EfTranscodeRepository.cs
+++ b/src/api/MixServer.Infrastructure/EF/Repositories/EfTranscodeRepository.cs
@@ -42,4 +42,9 @@ public class EfTranscodeRepository(MixServerDbContext context) : ITranscodeRepos
         
         return transcode;
     }
+
+    public void Remove(Guid transcodeId)
+    { 
+        context.Transcodes.RemoveRange(context.Transcodes.Where(s => s.Id == transcodeId));
+    }
 }

--- a/src/api/MixServer.Infrastructure/EF/Repositories/EfTranscodeRepository.cs
+++ b/src/api/MixServer.Infrastructure/EF/Repositories/EfTranscodeRepository.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using MixServer.Domain.Exceptions;
+using MixServer.Domain.FileExplorer.Entities;
 using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.Streams.Entities;
 using MixServer.Domain.Streams.Repositories;
+using MixServer.Infrastructure.EF.Extensions;
 
 namespace MixServer.Infrastructure.EF.Repositories;
 
@@ -10,37 +12,24 @@ public class EfTranscodeRepository(MixServerDbContext context) : ITranscodeRepos
 {
     public async Task<Transcode> GetAsync(Guid id)
     {
-        return await context.Transcodes.SingleOrDefaultAsync(s => s.Id == id)
+        return await context.Transcodes
+                   .IncludeNode()
+                   .SingleOrDefaultAsync(s => s.Id == id)
                ?? throw new NotFoundException(nameof(Transcode), id);
-    }
-
-    public async Task<Transcode> GetAsync(NodePath nodePath)
-    {
-        return await GetOrDefaultAsync(nodePath) ?? throw new NotFoundException(nameof(Transcode), nodePath.AbsolutePath);
     }
 
     public Task<Transcode?> GetOrDefaultAsync(NodePath nodePath)
     {
-        return context.Transcodes.SingleOrDefaultAsync(s => s.AbsolutePath == nodePath.AbsolutePath);
+        return context.Transcodes
+            .IncludeNode()
+            .SingleOrDefaultAsync(s => 
+                s.Node != null &&
+                s.Node.RootChild.RelativePath == nodePath.RootPath && s.Node.RelativePath == nodePath.RelativePath);
     }
 
-    public async Task<Transcode> GetOrAddAsync(NodePath nodePath)
+    public async Task AddAsync(Transcode transcode)
     {
-        var existing = await GetOrDefaultAsync(nodePath);
-        
-        if (existing is not null)
-        {
-            return existing;
-        }
-
-        var transcode = new Transcode
-        {
-            Id = Guid.NewGuid(),
-            AbsolutePath = nodePath.AbsolutePath,
-        };
         await context.Transcodes.AddAsync(transcode);
-        
-        return transcode;
     }
 
     public void Remove(Guid transcodeId)

--- a/src/api/MixServer.Infrastructure/Files/Services/FileService.cs
+++ b/src/api/MixServer.Infrastructure/Files/Services/FileService.cs
@@ -37,13 +37,13 @@ public class FileService(
     public async Task<IFileExplorerFolder> GetFolderOrRootAsync(NodePath? nodePath)
     {
         // If no folder is specified return the root folder
-        if (nodePath is null)
+        if (nodePath is null || nodePath.IsRoot)
         {
             return rootFolder;
         }
 
         // The folder is out of bounds return the root folder instead
-        if (!rootFolder.BelongsToRootChild(nodePath.RootPath))
+        if (!rootFolder.DescendantOfRoot(nodePath))
         {
             throw new ForbiddenRequestException("You do not have permission to access this folder");
         }

--- a/src/api/MixServer.Infrastructure/Files/Services/MimeTypeService.cs
+++ b/src/api/MixServer.Infrastructure/Files/Services/MimeTypeService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.StaticFiles;
+using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.FileExplorer.Services;
 using MixServer.Infrastructure.Files.Constants;
 
@@ -7,14 +8,14 @@ namespace MixServer.Infrastructure.Files.Services;
 public class MimeTypeService(FileExtensionContentTypeProvider fileExtensionContentTypeProvider)
     : IMimeTypeService
 {
-    public string GetMimeType(string absolutePath, string extension)
+    public string GetMimeType(NodePath nodePath)
     {
-        if (fileExtensionContentTypeProvider.TryGetContentType(absolutePath, out var contentType))
+        if (fileExtensionContentTypeProvider.TryGetContentType(nodePath.AbsolutePath, out var contentType))
         {
             return contentType;
         }
 
-        return extension switch
+        return nodePath.Extension switch
         {
             ".flac" => MimeTypeConstants.AudioFlac,
             ".ogx" => MimeTypeConstants.ApplicationOgg,

--- a/src/api/MixServer.Infrastructure/Migrations/20250525100932_BasicNodeEntities.Designer.cs
+++ b/src/api/MixServer.Infrastructure/Migrations/20250525100932_BasicNodeEntities.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MixServer.Infrastructure.EF;
 
@@ -10,9 +11,11 @@ using MixServer.Infrastructure.EF;
 namespace MixServer.Infrastructure.Migrations
 {
     [DbContext(typeof(MixServerDbContext))]
-    partial class MixServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250525100932_BasicNodeEntities")]
+    partial class BasicNodeEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.1");

--- a/src/api/MixServer.Infrastructure/Migrations/20250525100932_BasicNodeEntities.cs
+++ b/src/api/MixServer.Infrastructure/Migrations/20250525100932_BasicNodeEntities.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MixServer.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class BasicNodeEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Transcodes_AbsolutePath",
+                table: "Transcodes");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "NodeId",
+                table: "Transcodes",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "NodeId",
+                table: "PlaybackSessions",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "NodeId",
+                table: "FolderSorts",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Nodes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    RelativePath = table.Column<string>(type: "TEXT", nullable: false),
+                    NodeType = table.Column<int>(type: "INTEGER", nullable: false),
+                    RootChildId = table.Column<Guid>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Nodes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Nodes_Nodes_RootChildId",
+                        column: x => x.RootChildId,
+                        principalTable: "Nodes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Transcodes_NodeId",
+                table: "Transcodes",
+                column: "NodeId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlaybackSessions_NodeId",
+                table: "PlaybackSessions",
+                column: "NodeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FolderSorts_NodeId",
+                table: "FolderSorts",
+                column: "NodeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Nodes_RootChildId_RelativePath",
+                table: "Nodes",
+                columns: new[] { "RootChildId", "RelativePath" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_FolderSorts_Nodes_NodeId",
+                table: "FolderSorts",
+                column: "NodeId",
+                principalTable: "Nodes",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PlaybackSessions_Nodes_NodeId",
+                table: "PlaybackSessions",
+                column: "NodeId",
+                principalTable: "Nodes",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Transcodes_Nodes_NodeId",
+                table: "Transcodes",
+                column: "NodeId",
+                principalTable: "Nodes",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_FolderSorts_Nodes_NodeId",
+                table: "FolderSorts");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PlaybackSessions_Nodes_NodeId",
+                table: "PlaybackSessions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Transcodes_Nodes_NodeId",
+                table: "Transcodes");
+
+            migrationBuilder.DropTable(
+                name: "Nodes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Transcodes_NodeId",
+                table: "Transcodes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PlaybackSessions_NodeId",
+                table: "PlaybackSessions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FolderSorts_NodeId",
+                table: "FolderSorts");
+
+            migrationBuilder.DropColumn(
+                name: "NodeId",
+                table: "Transcodes");
+
+            migrationBuilder.DropColumn(
+                name: "NodeId",
+                table: "PlaybackSessions");
+
+            migrationBuilder.DropColumn(
+                name: "NodeId",
+                table: "FolderSorts");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Transcodes_AbsolutePath",
+                table: "Transcodes",
+                column: "AbsolutePath",
+                unique: true);
+        }
+    }
+}

--- a/src/api/MixServer.Infrastructure/Queueing/Models/FolderQueueSortItem.cs
+++ b/src/api/MixServer.Infrastructure/Queueing/Models/FolderQueueSortItem.cs
@@ -1,6 +1,6 @@
 ﻿namespace MixServer.Infrastructure.Queueing.Models;
 
-public class FolderQueueSortItem(Guid id, string absoluteFilePath, int position) : QueueSortItem(id, absoluteFilePath)
+public class FolderQueueSortItem : QueueSortItem
 {
-    public int Position { get; set; } = position;
+    public required int Position { get; set; }
 }

--- a/src/api/MixServer.Infrastructure/Queueing/Models/QueueSortItem.cs
+++ b/src/api/MixServer.Infrastructure/Queueing/Models/QueueSortItem.cs
@@ -1,8 +1,10 @@
-﻿namespace MixServer.Infrastructure.Queueing.Models;
+﻿using MixServer.Domain.FileExplorer.Models;
 
-public abstract class QueueSortItem(Guid id, string absoluteFilePath)
+namespace MixServer.Infrastructure.Queueing.Models;
+
+public abstract class QueueSortItem
 {
-    public Guid Id { get; } = id;
+    public required Guid Id { get; init; }
 
-    public string AbsoluteFilePath { get; } = absoluteFilePath;
+    public required NodePath NodePath { get; init; }
 }

--- a/src/api/MixServer.Infrastructure/Queueing/Models/UserQueueSortItem.cs
+++ b/src/api/MixServer.Infrastructure/Queueing/Models/UserQueueSortItem.cs
@@ -1,9 +1,8 @@
 ﻿namespace MixServer.Infrastructure.Queueing.Models;
 
-public class UserQueueSortItem(Guid id, string absoluteFilePath, Guid? previousFolderItemId)
-    : QueueSortItem(id, absoluteFilePath)
+public class UserQueueSortItem : QueueSortItem
 {
-    public Guid? PreviousFolderItemId { get; } = previousFolderItemId;
+    public required Guid? PreviousFolderItemId { get; init; }
 
-    public DateTime Added { get; set; } = DateTime.UtcNow;
+    public DateTime Added { get; } = DateTime.UtcNow;
 }

--- a/src/api/MixServer.Infrastructure/Queueing/Services/QueueService.cs
+++ b/src/api/MixServer.Infrastructure/Queueing/Services/QueueService.cs
@@ -23,7 +23,6 @@ public class QueueService(
     ICurrentUserRepository currentUserRepository,
     IFileService fileService,
     ILogger<QueueService> logger,
-    IRootFileExplorerFolder rootFileExplorerFolder,
     IQueueRepository queueRepository,
     IUnitOfWork unitOfWork)
     : IQueueService
@@ -51,11 +50,11 @@ public class QueueService(
     {
         var queue = queueRepository.GetOrAddQueue(currentUserRepository.CurrentUserId);
 
-        queue.CurrentFolderPath = rootFileExplorerFolder.GetNodePath(nextSession.GetParentFolderPathOrThrow());
+        queue.CurrentFolderPath = nextSession.NodeEntity.Path.Parent;
         queue.ClearUserQueue();
         
         var files = await GetPlayableFilesInFolderAsync(queue.CurrentFolderPath);
-        var nextSessionPath = rootFileExplorerFolder.GetNodePath(nextSession.AbsolutePath);
+        var nextSessionPath = nextSession.NodeEntity.Path;
         
         if (files.All(a => !a.Path.IsEqualTo(nextSessionPath)))
         {

--- a/src/api/MixServer.Infrastructure/Queueing/Services/QueueService.cs
+++ b/src/api/MixServer.Infrastructure/Queueing/Services/QueueService.cs
@@ -23,6 +23,7 @@ public class QueueService(
     ICurrentUserRepository currentUserRepository,
     IFileService fileService,
     ILogger<QueueService> logger,
+    IRootFileExplorerFolder rootFileExplorerFolder,
     IQueueRepository queueRepository,
     IUnitOfWork unitOfWork)
     : IQueueService
@@ -50,17 +51,19 @@ public class QueueService(
     {
         var queue = queueRepository.GetOrAddQueue(currentUserRepository.CurrentUserId);
 
-        queue.CurrentFolderAbsolutePath = nextSession.GetParentFolderPathOrThrow();
+        queue.CurrentFolderPath = rootFileExplorerFolder.GetNodePath(nextSession.GetParentFolderPathOrThrow());
         queue.ClearUserQueue();
         
-        var files = await GetPlayableFilesInFolderAsync(queue.CurrentFolderAbsolutePath);
-        if (files.All(a => a.AbsolutePath != nextSession.AbsolutePath))
+        var files = await GetPlayableFilesInFolderAsync(queue.CurrentFolderPath);
+        var nextSessionPath = rootFileExplorerFolder.GetNodePath(nextSession.AbsolutePath);
+        
+        if (files.All(a => !a.Path.IsEqualTo(nextSessionPath)))
         {
-            files.Add(fileService.GetFile(nextSession.AbsolutePath));
+            files.Add(fileService.GetFile(nextSessionPath));
         }
 
         queue.RegenerateFolderQueueSortItems(files);
-        queue.SetQueuePositionFromFolderItemOrThrow(nextSession.AbsolutePath);
+        queue.SetQueuePositionFromFolderItemOrThrow(nextSessionPath);
 
         var queueSnapshot = GenerateQueueSnapshot(queue, files);
 
@@ -160,7 +163,7 @@ public class QueueService(
     {
         var queue = queueRepository.GetOrAddQueue(currentUserRepository.CurrentUserId);
      
-        var files = await GetPlayableFilesInFolderAsync(queue.CurrentFolderAbsolutePath);
+        var files = await GetPlayableFilesInFolderAsync(queue.CurrentFolderPath);
 
         queue.Sort(files);
 
@@ -185,9 +188,9 @@ public class QueueService(
                    queue.CurrentQueuePositionId.ToString() ?? "unknown");
     }
 
-    public string? GetCurrentQueueFolderAbsolutePath()
+    public NodePath? GetCurrentQueueFolderPath()
     {
-        return queueRepository.GetOrAddQueue(currentUserRepository.CurrentUserId).CurrentFolderAbsolutePath;
+        return queueRepository.GetOrAddQueue(currentUserRepository.CurrentUserId).CurrentFolderPath;
     }
 
     public async Task<QueueSnapshot> GenerateQueueSnapshotAsync()
@@ -199,7 +202,7 @@ public class QueueService(
     
     private async Task<QueueSnapshot> GenerateQueueSnapshotAsync(UserQueue userQueue)
     {
-        return GenerateQueueSnapshot(userQueue, await GetPlayableFilesInFolderAsync(userQueue.CurrentFolderAbsolutePath));
+        return GenerateQueueSnapshot(userQueue, await GetPlayableFilesInFolderAsync(userQueue.CurrentFolderPath));
     }
     
     private QueueSnapshot GenerateQueueSnapshot(UserQueue userQueue, IEnumerable<IFileExplorerFileNode> folderFiles)
@@ -210,9 +213,8 @@ public class QueueService(
         allFiles.AddRange(folderFiles);
 
         var distinctFiles = allFiles
-            .Where(w => !string.IsNullOrWhiteSpace(w.AbsolutePath))
-            .DistinctBy(d => d.AbsolutePath)
-            .ToDictionary(k => k.AbsolutePath, v => v);
+            .DistinctBy(d => d.Path.AbsolutePath)
+            .ToDictionary(k => k.Path, v => v);
 
         var items = userQueue.GenerateQueueSnapshotItems(distinctFiles);
         
@@ -226,14 +228,14 @@ public class QueueService(
         return new QueueSnapshot(userQueue.CurrentQueuePositionId, previousValidOffset, nextValidOffset, items);
     }
 
-    private async Task<List<IFileExplorerFileNode>> GetPlayableFilesInFolderAsync(string? absoluteFolderPath)
+    private async Task<List<IFileExplorerFileNode>> GetPlayableFilesInFolderAsync(NodePath? nodePath)
     {
-        if (string.IsNullOrWhiteSpace(absoluteFolderPath))
+        if (nodePath is null)
         {
             return [];
         }
 
-        var folder = await fileService.GetFolderAsync(absoluteFolderPath);
+        var folder = await fileService.GetFolderAsync(nodePath);
 
         return folder.GenerateSortedChildren<IFileExplorerFileNode>()
             .Where(w => w.PlaybackSupported)

--- a/src/api/MixServer.Infrastructure/Sessions/Services/PlaybackTrackingService.cs
+++ b/src/api/MixServer.Infrastructure/Sessions/Services/PlaybackTrackingService.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MixServer.Domain.Callbacks;
 using MixServer.Domain.Exceptions;
-using MixServer.Domain.FileExplorer.Models;
 using MixServer.Domain.Persistence;
 using MixServer.Domain.Sessions.Entities;
 using MixServer.Domain.Sessions.Enums;
@@ -21,7 +20,6 @@ public class PlaybackTrackingService(
     ILogger<PlaybackTrackingService> logger,
     ILoggerFactory loggerFactory,
     IReadWriteLock readWriteLock,
-    IRootFileExplorerFolder rootFolder,
     IServiceProvider serviceProvider)
     : IPlaybackTrackingService
 {
@@ -72,7 +70,7 @@ public class PlaybackTrackingService(
     {
         readWriteLock.ForWrite(() =>
         {
-            var nodePath = rootFolder.GetNodePath(session.AbsolutePath);
+            var nodePath = session.NodeEntity.Path;
             
             if (_playingItems.TryGetValue(session.UserId, out var existingItem))
             {

--- a/src/api/MixServer.Infrastructure/Sessions/Services/SessionService.cs
+++ b/src/api/MixServer.Infrastructure/Sessions/Services/SessionService.cs
@@ -57,19 +57,19 @@ public class SessionService(
         
         var device = requestedPlaybackDeviceAccessor.PlaybackDevice;
         
-        var file = folderCacheService.GetFile(request.AbsoluteFilePath);
+        var file = folderCacheService.GetFile(request.NodePath);
 
         canPlayOnDeviceValidator.ValidateCanPlayOrThrow(device, file);
 
-        await currentUserRepository.LoadPlaybackSessionAsync(request.AbsoluteFilePath);
-        var session = user.PlaybackSessions.SingleOrDefault(s => s.AbsolutePath == request.AbsoluteFilePath);
+        await currentUserRepository.LoadPlaybackSessionAsync(request.NodePath);
+        var session = user.PlaybackSessions.SingleOrDefault(s => s.AbsolutePath == request.NodePath.AbsolutePath);
 
         if (session == null)
         {
             session = new PlaybackSession
             {
                 Id = Guid.NewGuid(),
-                AbsolutePath = request.AbsoluteFilePath,
+                AbsolutePath = request.NodePath.AbsolutePath,
                 LastPlayed = dateTimeProvider.UtcNow,
                 UserId = user.Id,
                 CurrentTime = TimeSpan.Zero

--- a/src/api/MixServer.Infrastructure/Users/Repository/CurrentUserRepository.cs
+++ b/src/api/MixServer.Infrastructure/Users/Repository/CurrentUserRepository.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using MixServer.Domain.Exceptions;
+using MixServer.Domain.FileExplorer.Models;
 using MixServer.Infrastructure.EF;
 using MixServer.Infrastructure.EF.Entities;
 using MixServer.Infrastructure.Users.Constants;
@@ -20,10 +21,10 @@ public interface ICurrentUserRepository
     Task LoadCurrentPlaybackSessionAsync();
     Task LoadAllPlaybackSessionsAsync();
     Task LoadPlaybackSessionAsync(Guid id);
-    Task LoadPlaybackSessionAsync(string absolutePath);
+    Task LoadPlaybackSessionAsync(NodePath nodePath);
     Task LoadPagedPlaybackSessionsAsync(int sessionStartIndex, int sessionPageSize);
     Task LoadAllFileSortsAsync();
-    Task LoadFileSortByAbsolutePathAsync(string absoluteFolderPath);
+    Task LoadFileSortByAbsolutePathAsync(NodePath nodePath);
     Task LoadAllDevicesAsync();
     Task LoadDeviceByIdAsync(Guid deviceId);
 }
@@ -108,12 +109,12 @@ public class CurrentUserRepository(
             .LoadAsync();
     }
 
-    public async Task LoadPlaybackSessionAsync(string absolutePath)
+    public async Task LoadPlaybackSessionAsync(NodePath nodePath)
     {
         await context.Entry(CurrentUser)
             .Collection(u => u.PlaybackSessions)
             .Query()
-            .Where(w => w.AbsolutePath == absolutePath)
+            .Where(w => w.AbsolutePath == nodePath.AbsolutePath)
             .LoadAsync();
     }
 
@@ -135,12 +136,12 @@ public class CurrentUserRepository(
             .LoadAsync();
     }
 
-    public async Task LoadFileSortByAbsolutePathAsync(string absoluteFolderPath)
+    public async Task LoadFileSortByAbsolutePathAsync(NodePath nodePath)
     {
         await context.Entry(CurrentUser)
             .Collection(c => c.FolderSorts)
             .Query()
-            .Where(w => w.AbsoluteFolderPath == absoluteFolderPath)
+            .Where(w => w.AbsoluteFolderPath == nodePath.AbsolutePath)
             .LoadAsync();
     }
 

--- a/src/api/MixServer.Infrastructure/Users/Services/DeviceTrackingService.cs
+++ b/src/api/MixServer.Infrastructure/Users/Services/DeviceTrackingService.cs
@@ -103,7 +103,7 @@ public class DeviceTrackingService(
             deviceState.DeviceId,
             deviceState.Online,
             deviceState.InteractedWith,
-            string.Join(", ", deviceState.Capabilities));
+            string.Join(", ", deviceState.Capabilities.Values.ToList()));
         await callbackService.DeviceStateUpdated(deviceState);
     }
 }

--- a/src/api/MixServer/Bootstrapper.cs
+++ b/src/api/MixServer/Bootstrapper.cs
@@ -6,6 +6,7 @@ using MixServer.Domain.Users.Services;
 using MixServer.Infrastructure.EF;
 using MixServer.Infrastructure.Sessions.Services;
 using MixServer.Infrastructure.Users.Services;
+using MixServer.Services;
 
 namespace MixServer;
 
@@ -15,6 +16,7 @@ public interface IBootstrapper
 }
 
 public class Bootstrapper(
+    AbsolutePathMigrationService absolutePathMigrationService,
     IWebHostEnvironment environment,
     MixServerDbContext context,
     IFileNotificationService fileNotificationService,
@@ -29,6 +31,8 @@ public class Bootstrapper(
         {
             await context.Database.MigrateAsync();
         }
+        
+        await absolutePathMigrationService.MigrateAsync();
 
         await userRoleService.InitializeAsync();
         await firstUserInitializationService.AddFirstUserIfNotExistsAsync();

--- a/src/api/MixServer/Controllers/NodeController.cs
+++ b/src/api/MixServer/Controllers/NodeController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using MixServer.Application.FileExplorer.Commands.RefreshFolder;
 using MixServer.Application.FileExplorer.Commands.SetFolderSort;
+using MixServer.Application.FileExplorer.Dtos;
 using MixServer.Application.FileExplorer.Queries.GetNode;
 using MixServer.Domain.Interfaces;
 
@@ -10,7 +11,7 @@ namespace MixServer.Controllers;
 [Produces("application/json")]
 [Route("api/[controller]")]
 public class NodeController(
-    IQueryHandler<GetFolderNodeQuery, FileExplorerFolderResponse> getFolderNodeQueryHandler,
+    IQueryHandler<NodePathRequestDto, FileExplorerFolderResponse> getFolderNodeQueryHandler,
     ICommandHandler<RefreshFolderCommand, FileExplorerFolderResponse> refreshFolderCommandHandler,
     ICommandHandler<SetFolderSortCommand> setFolderSortCommandHandler)
     : ControllerBase
@@ -19,7 +20,7 @@ public class NodeController(
     [ProducesResponseType(typeof(FileExplorerFolderResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetNode([FromQuery] GetFolderNodeQuery query)
+    public async Task<IActionResult> GetNode([FromQuery] NodePathRequestDto query)
     {
         return Ok(await getFolderNodeQueryHandler.HandleAsync(query));
     }

--- a/src/api/MixServer/Controllers/StreamController.cs
+++ b/src/api/MixServer/Controllers/StreamController.cs
@@ -20,7 +20,7 @@ public class StreamController(IQueryHandler<GetStreamQuery, StreamFile> getStrea
             SecurityParameters = securityParameters
         });
         
-        return new PhysicalFileResult(stream.FilePath, stream.ContentType)
+        return new PhysicalFileResult(stream.FilePath.AbsolutePath, stream.ContentType)
         {
             EnableRangeProcessing = true
         };

--- a/src/api/MixServer/Middleware/CurrentUserMiddleware.cs
+++ b/src/api/MixServer/Middleware/CurrentUserMiddleware.cs
@@ -14,6 +14,14 @@ public class CurrentUserMiddleware(
         ISessionService sessionService,
         IQueueService queueService)
     {
+        // We don't care if the user is not loaded for stream requests as they don't use the current user
+        // Instead they have there own StreamKey authentication
+        if (context.Request.Path.StartsWithSegments("/api/stream"))
+        {
+            await next(context);
+            return;
+        }
+        
         await currentUserRepository.LoadUserAsync();
         
         if (currentUserRepository.CurrentUserLoaded)

--- a/src/api/MixServer/Program.cs
+++ b/src/api/MixServer/Program.cs
@@ -150,6 +150,8 @@ builder.Services
 
 builder.Services.AddHostedService<MediaInfoService>();
 
+builder.Services.AddTransient<AbsolutePathMigrationService>();
+
 // API Controllers
 builder.Services.AddControllers()
     .AddNewtonsoftJson(options => { options.SerializerSettings.Converters.Add(new StringEnumConverter()); });

--- a/src/api/MixServer/Services/AbsolutePathMigrationService.cs
+++ b/src/api/MixServer/Services/AbsolutePathMigrationService.cs
@@ -1,0 +1,197 @@
+using Microsoft.EntityFrameworkCore;
+using MixServer.Domain.FileExplorer.Entities;
+using MixServer.Domain.FileExplorer.Models;
+using MixServer.Infrastructure.EF;
+using MixServer.Infrastructure.EF.Extensions;
+
+namespace MixServer.Services;
+#pragma warning disable CS0618 // Type or member is obsolete - used for migration purposes
+public class AbsolutePathMigrationService(
+    MixServerDbContext context,
+    ILogger<AbsolutePathMigrationService> logger,
+    IRootFileExplorerFolder rootFolder)
+{
+    public async Task MigrateAsync()
+    {
+        logger.LogInformation("Starting absolute path migration...");
+
+        var rootChildNodes = await EnsureRootChildNodesExistAsync();
+
+        await MigratePlaybackSessionsAsync(rootChildNodes);
+        await MigrateFolderSortsAsync(rootChildNodes);
+        await MigrateTranscodesAsync(rootChildNodes);
+        
+        logger.LogInformation("Absolute path migration completed successfully");
+    }
+
+    private async Task<Dictionary<string, FileExplorerRootChildNodeEntity>> EnsureRootChildNodesExistAsync()
+    {
+        logger.LogInformation("Creating root child nodes if they do not exist...");
+        var rootChildNodes = await context.Nodes
+            .OfType<FileExplorerRootChildNodeEntity>()
+            .ToDictionaryAsync(k => k.RelativePath, v => v);
+        foreach (var rootChild in rootFolder.Children.Where(w => !rootChildNodes.ContainsKey(w.Path.RootPath)))
+        {
+            var rootChildEntity = new FileExplorerRootChildNodeEntity
+            {
+                Id = Guid.NewGuid(),
+                RelativePath = rootChild.Path.RootPath
+            };
+            await context.Nodes.AddAsync(rootChildEntity);
+            rootChildNodes[rootChild.Path.RootPath] = rootChildEntity;
+            logger.LogInformation("Created root child node for path {RootPath}", rootChild.Path.RootPath);
+        }
+        await context.SaveChangesAsync();
+        logger.LogInformation("Root child nodes creation completed");
+        
+        return rootChildNodes;
+    }
+    
+    private async Task MigratePlaybackSessionsAsync(Dictionary<string, FileExplorerRootChildNodeEntity> rootChildNodes)
+    {
+        logger.LogInformation("Clearing absolute paths in playback sessions...");
+        await foreach (var session in context.PlaybackSessions
+                           .IncludeNode()
+                           .Where(w => w.AbsolutePath != string.Empty)
+                           .AsAsyncEnumerable())
+        {
+            logger.LogInformation("Processing session {SessionId} with absolute path {AbsolutePath}", session.Id, session.AbsolutePath);
+            var nodePath = rootFolder.GetNodePath(session.AbsolutePath);
+            
+            var file = await context.Nodes.OfType<FileExplorerFileNodeEntity>()
+                .Include(i => i.RootChild)
+                .FirstOrDefaultAsync(f => f.RootChild.RelativePath == nodePath.RootPath && f.RelativePath == nodePath.RelativePath);
+
+            if (file is null)
+            {
+                logger.LogInformation("File not found for session {SessionId} with absolute path {AbsolutePath}", session.Id, session.AbsolutePath);
+                
+                var root = rootChildNodes[nodePath.RootPath];
+                file = new FileExplorerFileNodeEntity
+                {
+                    Id = Guid.NewGuid(),
+                    RelativePath = nodePath.RelativePath,
+                    RootChild = root
+                };
+                await context.Nodes.AddAsync(file);
+            }
+            else
+            {
+                var root = rootChildNodes[nodePath.RootPath];
+                if (file.RootChild.Id != root.Id)
+                {
+                    logger.LogInformation("Updating file {FileId} root child from {OldRootId} to {NewRootId}", file.Id, file.RootChild.Id, root.Id);
+                    file.RootChild = root;
+                }
+            }
+
+            session.Node = file;
+            session.NodeId = file.Id;
+            session.AbsolutePath = string.Empty; // Clear the absolute path after migration to indicate it has been processed.
+            logger.LogInformation("Session {SessionId} processed successfully", session.Id);
+        }
+        
+        await context.SaveChangesAsync();
+        logger.LogInformation("Finished clearing absolute paths in playback sessions");
+    }
+    
+    private async Task MigrateFolderSortsAsync(Dictionary<string, FileExplorerRootChildNodeEntity> rootChildNodes)
+    {
+        logger.LogInformation("Clearing absolute paths in folder sorts...");
+
+        await foreach (var sort in context.FolderSorts
+                     .IncludeNode()
+                     .Where(w => w.AbsoluteFolderPath != string.Empty)
+                     .AsAsyncEnumerable())
+        {
+            logger.LogInformation("Processing folder sort {FolderSortId} with absolute path {AbsolutePath}", sort.Id, sort.AbsoluteFolderPath);
+            var nodePath = rootFolder.GetNodePath(sort.AbsoluteFolderPath);
+            
+            var folder = await context.Nodes.OfType<FileExplorerFolderNodeEntity>()
+                .Include(i => i.RootChild)
+                .FirstOrDefaultAsync(f => f.RootChild.RelativePath == nodePath.RootPath && f.RelativePath == nodePath.RelativePath);
+
+            if (folder is null)
+            {
+                logger.LogInformation("Folder not found for sort {FolderSortId} with absolute path {AbsolutePath}", sort.Id, sort.AbsoluteFolderPath);
+                
+                var root = rootChildNodes[nodePath.RootPath];
+                folder = new FileExplorerFolderNodeEntity
+                {
+                    Id = Guid.NewGuid(),
+                    RelativePath = nodePath.RelativePath,
+                    RootChild = root
+                };
+                await context.Nodes.AddAsync(folder);
+            }
+            else
+            {
+                var root = rootChildNodes[nodePath.RootPath];
+                if (folder.RootChildId != root.Id)
+                {
+                    logger.LogInformation("Updating folder {FolderId} root child to {RootChildId}", folder.Id, rootChildNodes[nodePath.RootPath].Id);
+                    folder.RootChild = root;
+                }
+            }
+
+            sort.Node = folder;
+            sort.NodeId = folder.Id;
+            sort.AbsoluteFolderPath = string.Empty; // Clear the absolute path after migration to indicate it has been processed.
+        }
+
+        await context.SaveChangesAsync();
+        logger.LogInformation("Finished clearing absolute paths in folder sorts");
+    }
+
+    private async Task MigrateTranscodesAsync(Dictionary<string, FileExplorerRootChildNodeEntity> rootChildNodes)
+    {
+        logger.LogInformation("Clearing absolute paths in transcodes...");
+        await foreach (var transcode in context.Transcodes
+                           .IncludeNode()
+                           .Where(w => w.AbsolutePath != string.Empty)
+                           .AsAsyncEnumerable())
+        {
+            logger.LogInformation("Processing transcode {TranscodeId} with absolute path {AbsolutePath}", transcode.Id,
+                transcode.AbsolutePath);
+
+            var nodePath = rootFolder.GetNodePath(transcode.AbsolutePath);
+
+            var file = await context.Nodes.OfType<FileExplorerFileNodeEntity>()
+                .Include(i => i.RootChild)
+                .FirstOrDefaultAsync(f =>
+                    f.RootChild.RelativePath == nodePath.RootPath && f.RelativePath == nodePath.RelativePath);
+
+            if (file is null)
+            {
+                logger.LogInformation("File not found for transcode {TranscodeId} with absolute path {AbsolutePath}",
+                    transcode.Id, transcode.AbsolutePath);
+                var root = rootChildNodes[nodePath.RootPath];
+                file = new FileExplorerFileNodeEntity
+                {
+                    Id = Guid.NewGuid(),
+                    RelativePath = nodePath.RelativePath,
+                    RootChild = root
+                };
+                await context.Nodes.AddAsync(file);
+            }
+            else
+            {
+                var root = rootChildNodes[nodePath.RootPath];
+                if (file.RootChildId != root.Id)
+                {
+                    logger.LogInformation("Updating transcode {TranscodeId} root child from {OldRootId} to {NewRootId}",
+                        transcode.Id, file.RootChild.Id, root.Id);
+                    file.RootChild = root;
+                }
+            }
+            
+            transcode.Node = file;
+            transcode.NodeId = file.Id;
+            transcode.AbsolutePath = string.Empty; // Clear the absolute path after migration to indicate it has been processed.
+        }
+        
+        await context.SaveChangesAsync();
+        logger.LogInformation("Finished clearing absolute paths in transcodes");
+    }
+}
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/api/MixServer/SignalR/Events/FileExplorerNodeDeletedDto.cs
+++ b/src/api/MixServer/SignalR/Events/FileExplorerNodeDeletedDto.cs
@@ -1,10 +1,11 @@
+using MixServer.Application.FileExplorer.Dtos;
 using MixServer.Application.FileExplorer.Queries.GetNode;
 
 namespace MixServer.SignalR.Events;
 
-public class FileExplorerNodeDeletedDto(FileExplorerFolderNodeResponse parent, string absolutePath)
+public class FileExplorerNodeDeletedDto
 {
-    public FileExplorerFolderNodeResponse Parent { get; } = parent;
+    public required FileExplorerFolderNodeResponse Parent { get; init; }
 
-    public string AbsolutePath { get; set; } = absolutePath;
+    public required NodePathDto NodePath { get; init; }
 }

--- a/src/api/MixServer/SignalR/Events/FileExplorerNodeUpdatedDto.cs
+++ b/src/api/MixServer/SignalR/Events/FileExplorerNodeUpdatedDto.cs
@@ -1,3 +1,4 @@
+using MixServer.Application.FileExplorer.Dtos;
 using MixServer.Application.FileExplorer.Queries.GetNode;
 
 namespace MixServer.SignalR.Events;
@@ -6,5 +7,5 @@ public class FileExplorerNodeUpdatedDto
 {
     public required FileExplorerNodeResponse Node { get; init; }
     public required int Index { get; init; }
-    public required string? OldAbsolutePath { get; init; }
+    public required NodePathDto? OldPath { get; init; }
 }

--- a/src/api/MixServer/SignalR/SignalRCallbackService.cs
+++ b/src/api/MixServer/SignalR/SignalRCallbackService.cs
@@ -218,7 +218,7 @@ public class SignalRCallbackService(
                 Node = nodeDto,
                 OldPath = oldNodePath is null
                     ? null
-                    : nodePathDtoConverter.Convert(oldNodePath)
+                    : nodePathDtoConverter.ConvertToResponse(oldNodePath)
             };
             var connections = user.GetConnections();
             var task = context.Clients.Clients(connections).FileExplorerNodeUpdated(dto);
@@ -235,7 +235,7 @@ public class SignalRCallbackService(
             .FileExplorerNodeDeleted(new FileExplorerNodeDeletedDto
             {
                 Parent = fileExplorerResponseConverter.Convert(parentNode),
-                NodePath = nodePathDtoConverter.Convert(nodePath)
+                NodePath = nodePathDtoConverter.ConvertToResponse(nodePath)
             });
     }
 
@@ -253,7 +253,7 @@ public class SignalRCallbackService(
     {
         var eventDto = new MediaInfoRemovedDto
         {
-            NodePaths = removedItems.Select(nodePathDtoConverter.Convert).ToList()
+            NodePaths = removedItems.Select(nodePathDtoConverter.ConvertToResponse).ToList()
         };
         
         return context.Clients.All.MediaInfoRemoved(eventDto);

--- a/src/clients/mix-server-client/src/app/app.component.ts
+++ b/src/clients/mix-server-client/src/app/app.component.ts
@@ -179,12 +179,6 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  public get folderBackButtonDisabled(): boolean {
-    return this.loadingStatus.loading ||
-      (this.currentFolder?.node.parent?.disabled ?? true) ||
-      this.currentFolder?.node.absolutePath === '';
-  }
-
   public logout(): void {
     this._authenticationService.logout();
   }

--- a/src/clients/mix-server-client/src/app/bottom-bar/audio-control-mobile/audio-control-mobile.component.html
+++ b/src/clients/mix-server-client/src/app/bottom-bar/audio-control-mobile/audio-control-mobile.component.html
@@ -4,7 +4,7 @@
 >
   <div headerText class="audio-control-header-text">
     <div class="session">
-      <strong>{{ playbackSession.currentNode.name }}</strong>
+      <strong>{{ playbackSession.currentNode.path.fileName }}</strong>
     </div>
 
     <div>

--- a/src/clients/mix-server-client/src/app/bottom-bar/audio-control/session/session.component.ts
+++ b/src/clients/mix-server-client/src/app/bottom-bar/audio-control/session/session.component.ts
@@ -29,7 +29,7 @@ export class SessionComponent implements OnInit, OnDestroy {
     this._playbackSessionRepository.currentSession$
       .pipe(takeUntil(this._unsubscribe$))
       .subscribe(s => {
-        this.fileName = s?.currentNode.name ?? '';
+        this.fileName = s?.currentNode.path.fileName ?? '';
         this.sessionCurrentDirectory = s?.currentNode.parent;
       });
   }

--- a/src/clients/mix-server-client/src/app/components/nodes/node-list/node-list-item/context-menu/delete-node/delete-node.component.ts
+++ b/src/clients/mix-server-client/src/app/components/nodes/node-list/node-list-item/context-menu/delete-node/delete-node.component.ts
@@ -55,7 +55,7 @@ export class DeleteNodeComponent extends ContextMenuButton implements OnInit, On
 
     const shouldDelete = await firstValueFrom(this._dialog.open(DeleteDialogComponent, {
       data: {
-        displayName: this.file.name
+        displayName: this.file.path.fileName
       }
     }).afterClosed());
 

--- a/src/clients/mix-server-client/src/app/components/nodes/node-list/node-list-item/interfaces/node-list-item-changed-event.ts
+++ b/src/clients/mix-server-client/src/app/components/nodes/node-list/node-list-item/interfaces/node-list-item-changed-event.ts
@@ -1,6 +1,6 @@
 import {FileExplorerNodeType} from "../../../../../main-content/file-explorer/enums/file-explorer-node-type";
 
 export interface NodeListItemChangedEvent {
-  id: string;
+  key: string;
   nodeType: FileExplorerNodeType
 }

--- a/src/clients/mix-server-client/src/app/components/nodes/node-list/node-list-item/interfaces/node-list-item-selected-event.ts
+++ b/src/clients/mix-server-client/src/app/components/nodes/node-list/node-list-item/interfaces/node-list-item-selected-event.ts
@@ -1,4 +1,4 @@
 export interface NodeListItemSelectedEvent {
-  id: string;
+  key: string;
   selected: boolean;
 }

--- a/src/clients/mix-server-client/src/app/components/nodes/node-list/node-list-item/node-list-item.component.html
+++ b/src/clients/mix-server-client/src/app/components/nodes/node-list/node-list-item/node-list-item.component.html
@@ -20,7 +20,7 @@
   >
     <div class="node-list-item-content-icon-container node-list-item">
       <app-node-list-item-icon
-        [loading]="loadingStatus.loading && !!loadingStatus.loadingIds[id]"
+        [loading]="loadingStatus.loading && !!loadingStatus.loadingIds[key]"
         [playingState]="playingState"
         [disabled]="loadingStatus.loading || disabled"
         [defaultIcon]="defaultIcon"

--- a/src/clients/mix-server-client/src/app/components/nodes/node-list/node-list-item/node-list-item.component.ts
+++ b/src/clients/mix-server-client/src/app/components/nodes/node-list/node-list-item/node-list-item.component.ts
@@ -17,7 +17,7 @@ export class NodeListItemComponent {
   @ContentChildren(ContextMenuButton) contextMenuButtons: QueryList<ContextMenuButton> | null | undefined;
 
   @Input()
-  public id: string = null!;
+  public key: string = null!;
 
   @Input()
   public nodeType: FileExplorerNodeType = FileExplorerNodeType.Folder;
@@ -56,7 +56,7 @@ export class NodeListItemComponent {
   }
 
   public get playingState(): FileExplorerPlayingState {
-    if (this.audioPlayerState.queueItemId === this.id || this.audioPlayerState.node?.absolutePath === this.id) {
+    if (this.audioPlayerState.queueItemId === this.key || this.audioPlayerState.node?.path.key === this.key) {
       return this.audioPlayerState.playing ? FileExplorerPlayingState.Playing : FileExplorerPlayingState.Paused;
     }
 
@@ -72,10 +72,10 @@ export class NodeListItemComponent {
       return;
     }
 
-    this.contentClick.emit({id: this.id, nodeType: this.nodeType});
+    this.contentClick.emit({key: this.key, nodeType: this.nodeType});
   }
 
   public onSelectedChange(selected: boolean): void {
-    this.selectedChange.emit({id: this.id, selected});
+    this.selectedChange.emit({key: this.key, selected});
   }
 }

--- a/src/clients/mix-server-client/src/app/history-page/history-page.component.html
+++ b/src/clients/mix-server-client/src/app/history-page/history-page.component.html
@@ -9,7 +9,7 @@
 >
   <app-node-list-item
     *ngFor="let session of sessions; last as last"
-    [id]="session.currentNode.absolutePath"
+    [key]="session.currentNode.path.key"
     [nodeType]="session.currentNode.type"
     [defaultIcon]="session.currentNode.mdIcon"
     [loadingStatus]="loadingStatus"
@@ -19,7 +19,7 @@
     (contentClick)="onNodeClick($event)"
   >
     <div appNodeListItemTitle>
-      {{ session.currentNode.name }}
+      {{ session.currentNode.path.fileName }}
     </div>
 
     <app-file-metadata-subtitle appNodeListItemSubtitle

--- a/src/clients/mix-server-client/src/app/history-page/history-page.component.ts
+++ b/src/clients/mix-server-client/src/app/history-page/history-page.component.ts
@@ -67,7 +67,7 @@ export class HistoryPageComponent implements OnInit, OnDestroy {
   }
 
   public onNodeClick(event: NodeListItemChangedEvent) {
-    const session = this.sessions.find(f => f.currentNode.absolutePath === event.id)
+    const session = this.sessions.find(f => f.currentNode.path.key === event.key)
 
     if (!session) {
       return;

--- a/src/clients/mix-server-client/src/app/main-content/file-explorer/file-explorer.component.html
+++ b/src/clients/mix-server-client/src/app/main-content/file-explorer/file-explorer.component.html
@@ -1,7 +1,7 @@
 <div>
   <app-node-list-item
     *ngIf="currentFolder.node.parent"
-    [id]="currentFolder.node.parent.absolutePath"
+    [key]="currentFolder.node.parent.path.key"
     [nodeType]="currentFolder.node.parent.type"
     [defaultIcon]="currentFolder.node.parent.mdIcon"
     [loadingStatus]="loadingStatus"
@@ -17,7 +17,7 @@
 
   <app-node-list-item
     *ngFor="let node of currentFolder.children; last as last"
-    [id]="node.absolutePath"
+    [key]="node.path.key"
     [nodeType]="node.type"
     [defaultIcon]="node.mdIcon"
     [loadingStatus]="loadingStatus"
@@ -27,7 +27,7 @@
     (contentClick)="onNodeClick($event)"
     >
     <div appNodeListItemTitle>
-      {{ node.name }}
+      {{ node.path.fileName }}
     </div>
 
     <app-file-metadata-subtitle appNodeListItemSubtitle

--- a/src/clients/mix-server-client/src/app/main-content/file-explorer/file-explorer.component.ts
+++ b/src/clients/mix-server-client/src/app/main-content/file-explorer/file-explorer.component.ts
@@ -68,12 +68,12 @@ export class FileExplorerComponent implements OnInit, OnDestroy {
   }
 
   public onNodeClick(event: NodeListItemChangedEvent): void {
-    if (this.currentFolder.node.parent && event.id === this.currentFolder.node.parent.absolutePath) {
+    if (this.currentFolder.node.parent && event.key === this.currentFolder.node.parent.path.key) {
       this.onFolderClick(this.currentFolder.node.parent);
       return;
     }
 
-    const childNode = this.currentFolder.children.find(s => s.absolutePath === event.id);
+    const childNode = this.currentFolder.children.find(s => s.path.key === event.key);
 
     if (childNode instanceof FileExplorerFolderNode) {
       this.onFolderClick(childNode);

--- a/src/clients/mix-server-client/src/app/main-content/file-explorer/folder-paste-form/folder-paste-form.component.ts
+++ b/src/clients/mix-server-client/src/app/main-content/file-explorer/folder-paste-form/folder-paste-form.component.ts
@@ -53,7 +53,7 @@ export class FolderPasteFormComponent implements OnInit, OnDestroy {
     }
 
     if (this._copyService.isMove &&
-      this.sourceNode.parent.absolutePath === this.currentFolder.node.absolutePath) {
+      this.sourceNode.parent.path.isEqual(this.currentFolder.node.path)) {
       this._copyService.resetForm();
       return;
     }
@@ -90,7 +90,7 @@ export class FolderPasteFormComponent implements OnInit, OnDestroy {
       sourceNode.exists = false;
 
       const suffix = maxCopyNumber === -1 ? '' : ` (${maxCopyNumber + 1})`;
-      sourceNode.name = `${nameSections.nameWithoutSuffix} - Copy${suffix}.${nameSections.extension}`
+      sourceNode.path.fileName = `${nameSections.nameWithoutSuffix} - Copy${suffix}.${nameSections.extension}`
     }
 
     await this._copyService.pasteNode(sourceNode, false);

--- a/src/clients/mix-server-client/src/app/main-content/file-explorer/folder-sort-form/folder-sort-form.component.ts
+++ b/src/clients/mix-server-client/src/app/main-content/file-explorer/folder-sort-form/folder-sort-form.component.ts
@@ -52,7 +52,7 @@ export class FolderSortFormComponent implements OnInit, OnDestroy {
     this._nodeRepository.currentFolder$
       .pipe(takeUntil(this._unsubscribe$))
       .subscribe(value => {
-        this.showForm = !!value.node.absolutePath && value.node.absolutePath !== '';
+        this.showForm = !value.node.path.empty;
 
         this.form.get(this.descendingKey)?.setValue(value.sort.descending);
         this.form.get(this.sortModeKey)?.setValue(value.sort.sortMode);

--- a/src/clients/mix-server-client/src/app/main-content/file-explorer/models/file-explorer-folder-node.ts
+++ b/src/clients/mix-server-client/src/app/main-content/file-explorer/models/file-explorer-folder-node.ts
@@ -1,9 +1,9 @@
 import {FileExplorerNode} from "./file-explorer-node";
 import {FileExplorerNodeType} from "../enums/file-explorer-node-type";
+import {NodePath} from "./node-path";
 
 export class FileExplorerFolderNode implements FileExplorerNode {
-  constructor(public name: string,
-              public absolutePath: string,
+  constructor(public path: NodePath,
               public type: FileExplorerNodeType,
               public exists: boolean,
               public creationTimeUtc: Date,
@@ -26,26 +26,23 @@ export class FileExplorerFolderNode implements FileExplorerNode {
       return false;
     }
 
-    return this.absolutePath === node.absolutePath;
+    return this.path.isEqual(node.path);
   }
 
   public static get Default(): FileExplorerFolderNode {
     return new FileExplorerFolderNode(
-      '',
-      '',
+      NodePath.Default,
       FileExplorerNodeType.Folder,
       false,
       new Date(),
       false,
       false,
-      null
-    );
+      null);
   }
 
   public copy(): FileExplorerFolderNode {
     return new FileExplorerFolderNode(
-      this.name,
-      this.absolutePath,
+      this.path.copy(),
       this.type,
       this.exists,
       this.creationTimeUtc,

--- a/src/clients/mix-server-client/src/app/main-content/file-explorer/models/file-explorer-node.ts
+++ b/src/clients/mix-server-client/src/app/main-content/file-explorer/models/file-explorer-node.ts
@@ -1,9 +1,9 @@
 import {FileExplorerFolderNode} from "./file-explorer-folder-node";
 import {FileExplorerNodeType} from "../enums/file-explorer-node-type";
+import {NodePath} from "./node-path";
 
 export interface FileExplorerNode {
-  name: string;
-  absolutePath: string;
+  path: NodePath;
   type: FileExplorerNodeType;
   creationTimeUtc: Date;
   exists: boolean;

--- a/src/clients/mix-server-client/src/app/main-content/file-explorer/models/node-path.ts
+++ b/src/clients/mix-server-client/src/app/main-content/file-explorer/models/node-path.ts
@@ -1,0 +1,53 @@
+export class NodePathHeader {
+  constructor(public rootPath: string,
+              public relativePath: string)
+  {
+  }
+
+  // this is not the absolute path, but the key to identify the node
+  // As the client should not need the logic to know different platforms path separators
+  public get key(): string {
+    return this.rootPath + ";" + this.relativePath;
+  }
+
+  public get empty(): boolean {
+    return this.rootPath === '' && this.relativePath === '';
+  }
+
+  public static get Default(): NodePathHeader {
+    return new NodePathHeader('', '');
+  }
+
+  public copy(): NodePathHeader {
+    return new NodePathHeader(this.rootPath, this.relativePath);
+  }
+
+  public isEqual(nodePathParent: NodePathHeader | null | undefined): boolean {
+    if (!nodePathParent) {
+      return false;
+    }
+
+    return this.rootPath === nodePathParent.rootPath && this.relativePath === nodePathParent.relativePath;
+  }
+}
+
+export class NodePath extends NodePathHeader {
+  constructor(rootPath: string,
+              relativePath: string,
+              public fileName: string,
+              public absolutePath: string,
+              public extension: string,
+              public parent: NodePathHeader,
+              public isRoot: boolean,
+              public isRootChild: boolean) {
+    super(rootPath, relativePath);
+  }
+
+  public static override get Default(): NodePath {
+    return new NodePath('', '', '', '', '', NodePathHeader.Default, false, false);
+  }
+
+  public override copy(): NodePath {
+    return new NodePath(this.rootPath, this.relativePath, this.fileName, this.absolutePath, this.extension, this.parent.copy(), this.isRoot, this.isRootChild);
+  }
+}

--- a/src/clients/mix-server-client/src/app/nav-bar/nav-bar.component.html
+++ b/src/clients/mix-server-client/src/app/nav-bar/nav-bar.component.html
@@ -13,7 +13,7 @@
     <div
          class="page-title">
       @if (currentPage === MenuLabel.Files && currentFolder && currentFolder.node.belongsToRootChild) {
-        {{ currentFolder.node.name }}
+        {{ currentFolder.node.path.fileName }}
       } @else if (currentPage) {
         {{ currentPage }}
       } @else {

--- a/src/clients/mix-server-client/src/app/queue-page/queue-page.component.html
+++ b/src/clients/mix-server-client/src/app/queue-page/queue-page.component.html
@@ -1,7 +1,7 @@
 <div>
   <app-node-list-item
     *ngFor="let queueItem of queue.items; last as last"
-    [id]="queueItem.id"
+    [key]="queueItem.id"
     [nodeType]="queueItem.type"
     [defaultIcon]="queueItem.mdIcon"
     [loadingStatus]="loadingStatus"

--- a/src/clients/mix-server-client/src/app/queue-page/queue-page.component.ts
+++ b/src/clients/mix-server-client/src/app/queue-page/queue-page.component.ts
@@ -71,12 +71,12 @@ export class QueuePageComponent implements OnInit, OnDestroy {
   }
 
   public onNodeClick(event: NodeListItemChangedEvent): void {
-    this._sessionService.setQueuePosition(event.id);
+    this._sessionService.setQueuePosition(event.key);
   }
 
   public onNodeSelectedChanged(e: NodeListItemSelectedEvent) {
     this._queueEditFormRepository.updateEditForm(form => {
-      form.selectedItems[e.id] = e.selected;
+      form.selectedItems[e.key] = e.selected;
     })
   }
 

--- a/src/clients/mix-server-client/src/app/services/audio-player/audio-player.service.ts
+++ b/src/clients/mix-server-client/src/app/services/audio-player/audio-player.service.ts
@@ -410,7 +410,7 @@ export class AudioPlayerService {
     }
 
     this._streamUrl = url;
-    this._transcode = !session.currentNode.clientPlaybackSupported;
+    this._transcode = session.currentNode.hasCompletedTranscode || !session.currentNode.clientPlaybackSupported;
 
     this._audioElementRepository.attachHls(this._streamUrl, this._transcode);
 

--- a/src/clients/mix-server-client/src/app/services/audio-player/audio-player.service.ts
+++ b/src/clients/mix-server-client/src/app/services/audio-player/audio-player.service.ts
@@ -374,16 +374,16 @@ export class AudioPlayerService {
     } catch (err) {
       if (err instanceof DOMException) {
         if (err.name === 'NotSupportedError') {
-          this._toastService.error(`${this._playbackSessionRepository.currentSession?.currentNode?.name} unsupported`, 'Not Supported');
+          this._toastService.error(`${this._playbackSessionRepository.currentSession?.currentNode?.path.fileName} unsupported`, 'Not Supported');
           this._sessionService.clearSession();
           this._loadingRepository.stopLoadingAction('RequestPlayback');
         } else {
           console.error(err);
-          this._toastService.error(`${this._playbackSessionRepository.currentSession?.currentNode?.name}: ${err.message}`, err.name);
+          this._toastService.error(`${this._playbackSessionRepository.currentSession?.currentNode?.path.fileName}: ${err.message}`, err.name);
         }
       } else if (err instanceof Error) {
         console.error(err);
-        this._toastService.error(`${this._playbackSessionRepository.currentSession?.currentNode?.name}: ${err.message}`, err.name);
+        this._toastService.error(`${this._playbackSessionRepository.currentSession?.currentNode?.path.fileName}: ${err.message}`, err.name);
       }
     }
   }

--- a/src/clients/mix-server-client/src/app/services/audio-player/audio-session.service.ts
+++ b/src/clients/mix-server-client/src/app/services/audio-player/audio-session.service.ts
@@ -13,7 +13,7 @@ export class AudioSessionService {
 
   public createMetadata(): AudioSessionService {
     this.metadata = new MediaMetadata({
-      title: this._playbackSessionRepository.currentSession?.currentNode?.name ?? ''
+      title: this._playbackSessionRepository.currentSession?.currentNode?.path.fileName ?? ''
     });
 
     return this;

--- a/src/clients/mix-server-client/src/app/services/audio-player/transcode.service.ts
+++ b/src/clients/mix-server-client/src/app/services/audio-player/transcode.service.ts
@@ -2,17 +2,20 @@ import { Injectable } from '@angular/core';
 import {FileExplorerFileNode} from "../../main-content/file-explorer/models/file-explorer-file-node";
 import {RequestTranscodeCommand} from "../../generated-clients/mix-server-clients";
 import {TranscodeApiService} from "../api.service";
+import {NodePathConverterService} from "../converters/node-path-converter.service";
 
 @Injectable({
   providedIn: 'root'
 })
 export class TranscodeService {
 
-  constructor(private _transcodeClient: TranscodeApiService) { }
+  constructor(private _nodePathConverter: NodePathConverterService,
+              private _transcodeClient: TranscodeApiService) { }
 
   public async requestTranscode(file: FileExplorerFileNode): Promise<void> {
-    await this._transcodeClient.request(file.absolutePath, client => client.requestTranscode(new RequestTranscodeCommand({
-      absoluteFilePath: file.absolutePath
+    await this._transcodeClient.request(file.path.key,
+        client => client.requestTranscode(new RequestTranscodeCommand({
+      nodePath: this._nodePathConverter.toRequestDto(file.path)
     })), 'Failed to request transcode file');
   }
 }

--- a/src/clients/mix-server-client/src/app/services/converters/file-explorer-node-converter.service.ts
+++ b/src/clients/mix-server-client/src/app/services/converters/file-explorer-node-converter.service.ts
@@ -15,12 +15,14 @@ import {FileExplorerFolderNode} from "../../main-content/file-explorer/models/fi
 import {FileExplorerFolder} from "../../main-content/file-explorer/models/file-explorer-folder";
 import {FileMetadataConverterService} from "./file-metadata-converter.service";
 import {AudioElementRepositoryService} from "../audio-player/audio-element-repository.service";
+import {NodePathConverterService} from "./node-path-converter.service";
 
 @Injectable({
   providedIn: 'root'
 })
 export class FileExplorerNodeConverterService {
   constructor(private _fileMetadataConverter: FileMetadataConverterService,
+              private _nodePathConverter: NodePathConverterService,
               private _audioElementRepository: AudioElementRepositoryService) {
   }
 
@@ -49,8 +51,7 @@ export class FileExplorerNodeConverterService {
     const clientPlaybackSupported = this._audioElementRepository.audio.canPlayType(metadata.mimeType) !== '';
 
     return new FileExplorerFileNode(
-      dto.name,
-      dto.absolutePath,
+      this._nodePathConverter.fromDto(dto.path),
       dto.type,
       dto.exists,
       dto.creationTimeUtc,
@@ -63,8 +64,7 @@ export class FileExplorerNodeConverterService {
 
   public fromFileExplorerFolderNode(dto: FileExplorerFolderNodeResponse): FileExplorerFolderNode {
     return new FileExplorerFolderNode(
-      dto.name,
-      dto.absolutePath,
+      this._nodePathConverter.fromDto(dto.path),
       dto.type,
       dto.exists,
       dto.creationTimeUtc,

--- a/src/clients/mix-server-client/src/app/services/converters/file-metadata-converter.service.ts
+++ b/src/clients/mix-server-client/src/app/services/converters/file-metadata-converter.service.ts
@@ -3,7 +3,6 @@ import {FileMetadataResponse, MediaInfoDto, NodePathDto} from "../../generated-c
 import {FileMetadata} from "../../main-content/file-explorer/models/file-metadata";
 import {TracklistConverterService} from "./tracklist-converter.service";
 import {MediaInfo} from "../../main-content/file-explorer/models/media-info";
-import {NodePath} from "../repositories/models/node-path";
 
 @Injectable({
   providedIn: 'root'
@@ -27,13 +26,5 @@ export class FileMetadataConverterService {
       dto.bitrate,
       this._tracklistConverter.createTracklistForm(dto.tracklist)
     )
-  }
-
-  public fromNodePathDto(dto: NodePathDto): NodePath {
-    return {
-      parentAbsolutePath: dto.parentAbsolutePath,
-      fileName: dto.fileName,
-      absolutePath: dto.absolutePath
-    }
   }
 }

--- a/src/clients/mix-server-client/src/app/services/converters/node-path-converter.service.ts
+++ b/src/clients/mix-server-client/src/app/services/converters/node-path-converter.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import {NodePathDto, NodePathHeaderDto, NodePathRequestDto} from "../../generated-clients/mix-server-clients";
+import {NodePath, NodePathHeader} from "../../main-content/file-explorer/models/node-path";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NodePathConverterService {
+
+  constructor() { }
+
+  public fromDto(dto: NodePathDto): NodePath {
+    return new NodePath(
+      dto.rootPath,
+      dto.relativePath,
+      dto.fileName,
+      dto.absolutePath,
+      dto.extension,
+      this.fromHeaderDto(dto.parent),
+      dto.isRoot,
+      dto.isRootChild
+    );
+  }
+
+  public fromHeaderDto(dto: NodePathHeaderDto): NodePathHeader {
+    return new NodePathHeader(
+      dto.rootPath,
+      dto.relativePath
+    );
+  }
+
+  public toRequestDto(nodePathHeader: NodePathHeader): NodePathRequestDto {
+    return new NodePathRequestDto({
+      rootPath: nodePathHeader.rootPath,
+      relativePath: nodePathHeader.relativePath
+    });
+  }
+}

--- a/src/clients/mix-server-client/src/app/services/nodes/copy-node.service.ts
+++ b/src/clients/mix-server-client/src/app/services/nodes/copy-node.service.ts
@@ -6,6 +6,7 @@ import {CopyNodeCommand} from "../../generated-clients/mix-server-clients";
 import {LoadingRepositoryService} from "../repositories/loading-repository.service";
 import {ToastService} from "../toasts/toast-service";
 import {NodeManagementApiService} from "../api.service";
+import {NodePathConverterService} from "../converters/node-path-converter.service";
 
 interface CopyNodeForm {
   sourceNode: FormControl<FileExplorerFileNode | null>;
@@ -24,6 +25,7 @@ export class CopyNodeService {
   private _form: FormGroup<CopyNodeForm>;
 
   constructor(private _formBuilder: FormBuilder,
+              private _nodePathConverter: NodePathConverterService,
               private _nodeManagementClient: NodeManagementApiService) {
     this._form = this.createForm();
   }
@@ -44,8 +46,9 @@ export class CopyNodeService {
     });
   }
 
-  async pasteNode(destinationNode: FileExplorerFileNode,
-            overwrite: boolean) {
+  async pasteNode(
+    destinationNode: FileExplorerFileNode,
+    overwrite: boolean) {
     this._form.patchValue({
       destinationNode,
       overwrite
@@ -60,11 +63,10 @@ export class CopyNodeService {
       return;
     }
 
-    await this._nodeManagementClient.request(sourceNode.absolutePath,
+    await this._nodeManagementClient.request(sourceNode.path.key,
       client => client.copyNode(new CopyNodeCommand({
-        sourceAbsolutePath: sourceNode.absolutePath,
-        destinationFolder: destinationNode.parent.absolutePath,
-        destinationName: destinationNode.name,
+        sourcePath: this._nodePathConverter.toRequestDto(sourceNode.path),
+        destinationPath: this._nodePathConverter.toRequestDto(destinationNode.path),
         overwrite,
         move: move ?? false
       })), 'Failed to copy node');

--- a/src/clients/mix-server-client/src/app/services/nodes/delete-node.service.ts
+++ b/src/clients/mix-server-client/src/app/services/nodes/delete-node.service.ts
@@ -2,18 +2,20 @@ import { Injectable } from '@angular/core';
 import {FileExplorerFileNode} from "../../main-content/file-explorer/models/file-explorer-file-node";
 import {DeleteNodeCommand} from "../../generated-clients/mix-server-clients";
 import {NodeManagementApiService} from "../api.service";
+import {NodePathConverterService} from "../converters/node-path-converter.service";
 
 @Injectable({
   providedIn: 'root'
 })
 export class DeleteNodeService {
 
-  constructor(private _nodeManagementClient: NodeManagementApiService) { }
+  constructor(private _nodePathConverter: NodePathConverterService,
+              private _nodeManagementClient: NodeManagementApiService) { }
 
   async delete(file: FileExplorerFileNode) {
-    await this._nodeManagementClient.request(file.absolutePath,
+    await this._nodeManagementClient.request(file.path.key,
       client => client.deleteNode(new DeleteNodeCommand({
-        absolutePath: file.absolutePath
-      })), `Error deleting ${file.name}`);
+        nodePath: this._nodePathConverter.toRequestDto(file.path)
+      })), `Error deleting ${file.path.fileName}`);
   }
 }

--- a/src/clients/mix-server-client/src/app/services/repositories/history-repository.service.ts
+++ b/src/clients/mix-server-client/src/app/services/repositories/history-repository.service.ts
@@ -65,7 +65,7 @@ export class HistoryRepositoryService {
   }
 
   private next(sessions: PlaybackSession[]) {
-    const folders = [...new Set(sessions.map(session => session.currentNode.parent.absolutePath))];
+    const folders = [...new Set(sessions.map(session => session.currentNode.parent.path))];
     folders.forEach(folder => {
       void this._nodeCache.loadDirectory(folder)
     })

--- a/src/clients/mix-server-client/src/app/services/repositories/models/node-path.ts
+++ b/src/clients/mix-server-client/src/app/services/repositories/models/node-path.ts
@@ -1,5 +1,0 @@
-﻿export interface NodePath {
-  parentAbsolutePath: string;
-  fileName: string;
-  absolutePath: string;
-}

--- a/src/clients/mix-server-client/src/app/services/repositories/models/queue-item.ts
+++ b/src/clients/mix-server-client/src/app/services/repositories/models/queue-item.ts
@@ -19,7 +19,7 @@ export class QueueItem {
   public file: FileExplorerFileNode;
 
   public get name(): string {
-    return this.file.name;
+    return this.file.path.fileName;
   }
 
   public get mdIcon(): string {

--- a/src/clients/mix-server-client/src/app/services/sessions/session.service.ts
+++ b/src/clients/mix-server-client/src/app/services/sessions/session.service.ts
@@ -10,6 +10,7 @@ import {CurrentPlaybackSessionRepositoryService} from "../repositories/current-p
 import {QueueRepositoryService} from "../repositories/queue-repository.service";
 import {QueueConverterService} from "../converters/queue-converter.service";
 import {QueueApiService, SessionApiService} from "../api.service";
+import {NodePathConverterService} from "../converters/node-path-converter.service";
 
 @Injectable({
     providedIn: 'root'
@@ -19,6 +20,7 @@ export class SessionService {
     constructor(
         private _playbackSessionConverter: PlaybackSessionConverterService,
         private _playbackSessionRepository: CurrentPlaybackSessionRepositoryService,
+        private _nodePathConverter: NodePathConverterService,
         private _sessionClient: SessionApiService,
         private _queueClient: QueueApiService,
         private _queueConverter: QueueConverterService,
@@ -26,10 +28,9 @@ export class SessionService {
     }
 
     public setFile(file: FileExplorerFileNode): void {
-        this._sessionClient.request(file.absolutePath,
+        this._sessionClient.request(file.path.key,
             client => client.setCurrentSession(new SetCurrentSessionCommand({
-                absoluteFolderPath: file.parent.absolutePath,
-                fileName: file.name
+              nodePath: this._nodePathConverter.toRequestDto(file.path)
             })), 'Failed to set current session')
             .then(result => result.success(dto => this.next(dto)));
     }

--- a/src/clients/mix-server-client/src/app/services/signalr/models/media-info-event.ts
+++ b/src/clients/mix-server-client/src/app/services/signalr/models/media-info-event.ts
@@ -1,5 +1,5 @@
-﻿import {NodePath} from "../../repositories/models/node-path";
-import {MediaInfo} from "../../../main-content/file-explorer/models/media-info";
+﻿import {MediaInfo} from "../../../main-content/file-explorer/models/media-info";
+import {NodePath} from "../../../main-content/file-explorer/models/node-path";
 
 export interface MediaInfoUpdatedEventItem {
   nodePath: NodePath

--- a/src/clients/mix-server-client/src/app/services/signalr/models/node-deleted-event.ts
+++ b/src/clients/mix-server-client/src/app/services/signalr/models/node-deleted-event.ts
@@ -1,7 +1,8 @@
 import {FileExplorerFolderNode} from "../../../main-content/file-explorer/models/file-explorer-folder-node";
+import {NodePath} from "../../../main-content/file-explorer/models/node-path";
 
 export class NodeDeletedEvent {
     constructor(public readonly parent: FileExplorerFolderNode,
-                public readonly absolutePath: string) {
+                public readonly nodePath: NodePath) {
     }
 }

--- a/src/clients/mix-server-client/src/app/services/signalr/models/node-updated-event.ts
+++ b/src/clients/mix-server-client/src/app/services/signalr/models/node-updated-event.ts
@@ -1,9 +1,10 @@
 import {FileExplorerNode} from "../../../main-content/file-explorer/models/file-explorer-node";
+import {NodePath} from "../../../main-content/file-explorer/models/node-path";
 
 export class NodeUpdatedEvent {
     constructor(public readonly node: FileExplorerNode,
                 public readonly index: number,
-                public readonly oldAbsolutePath?: string)
+                public readonly oldPath?: NodePath)
     {
     }
 }

--- a/src/clients/mix-server-client/src/app/services/title/title.service.ts
+++ b/src/clients/mix-server-client/src/app/services/title/title.service.ts
@@ -35,14 +35,14 @@ export class TitleService {
 
     this._nodeRepository.currentFolder$
       .subscribe(folder => {
-        this._currentFolderName = folder.node.name;
+        this._currentFolderName = folder.node.path.fileName;
         this.setTitle();
       });
 
     this._audioStateRepository.state$
       .subscribe(state => {
-        this._currentPlayingFile = state?.playing && state.node?.name
-          ? state.node.name
+        this._currentPlayingFile = state?.playing && state.node?.path.fileName
+          ? state.node.path.fileName
           : null;
 
         this.setTitle();


### PR DESCRIPTION
To work towards indexing all files for search purposes we need to split up paths into root / relative, something that should have been done from the start.

This change leaves in place the AbsolutePath property for now for migration purposes but will later be removed